### PR TITLE
[80639] Fix foreach sample code error

### DIFF
--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -69,9 +69,9 @@ unset($değer); // son eleman da işlendiğine göre gönderimi kaldıralım
    <programlisting role="php">
 <![CDATA[
 <?php
-$dizi = array("bir", "iki", "üç");
-foreach ($arr as &$value) {
-    değer = değer * 2;
+$dizi = array(1, 2, 3, 4);
+foreach ($dizi as &$değer) {
+    $değer = $değer * 2;
 }
 // $dizi şimdi array(2, 4, 6, 8)
 


### PR DESCRIPTION
This PR fixes the document bug described in [`80639`](https://bugs.php.net/bug.php?id=80639). This issue has been open for a few months so thought I'd submit a fix for it so it can be closed.

The issue itself doesn't require knowledge in Turkish - of which I have zero, since the code should be the same as in the example above as it's a note about not using `unset`. So it was a simple copy 'n paste fix basically.