### PR TITLE
Add translation for get_error_handler() and get_exception_handler()

### DIFF
--- a/reference/errorfunc/functions/get-error-handler.xml
+++ b/reference/errorfunc/functions/get-error-handler.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 99916949eb29e72ffa97be78170e2439db69dae9 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.get-error-handler" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>get_error_handler</refname>
+  <refpurpose>Kullanıcı tanımlı hata işleyici işlevi döndürür</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>callable</type><type>null</type></type><methodname>get_error_handler</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Varsa, geçerli hata işleyici işlevini döndürür.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Tanımlanmışsa, geçerli hata işleyiciyi döndürür.
+   Yerleşik hata işleyici kullanılıyorsa &null; döndürülür.
+  </simpara>
+  <simpara>
+   Döndürülen işleyici, tanımlamak için
+   <function>set_error_handler</function> işlevine iletilen
+   çağrılabilir değerin tam karşılığıdır.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>get_error_handler</function> örneği</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$handler = function (int $errno, string $errstr, ?string $errfile, ?int $errline) {
+     echo "Error: " . $errstr . "\n";
+};
+
+var_dump(get_error_handler()); // NULL
+
+set_error_handler($handler);
+
+var_dump(get_error_handler() === $handler); // bool(true)
+
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <tip>
+    <simpara>
+     PHP 8.5.0 öncesinde bu işlevsellik aşağıdaki çokdoldurum ile
+     sağlanabilir:
+    </simpara>
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+if (!function_exists('get_error_handler')) {
+    function noop_error_handler() {
+    }
+    function get_error_handler(): ?callable {
+        $handler = set_error_handler('noop_error_handler');
+        restore_error_handler();
+        return $handler;
+    }
+}
+?>
+]]>
+    </programlisting>
+   </informalexample>
+  </tip>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>error_reporting</function></member>
+   <member><function>set_error_handler</function></member>
+   <member><function>restore_error_handler</function></member>
+   <member><function>trigger_error</function></member>
+   <member><link linkend="errorfunc.constants">error level constants</link></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/errorfunc/functions/get-exception-handler.xml
+++ b/reference/errorfunc/functions/get-exception-handler.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 99916949eb29e72ffa97be78170e2439db69dae9 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.get-exception-handler" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>get_exception_handler</refname>
+  <refpurpose>Kullanıcı tanımlı istisna işleyici işlevi döndürür</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>callable</type><type>null</type></type><methodname>get_exception_handler</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Varsa, geçerli istisna işleyici işlevini döndürür.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Tanımlanmış geçerli istisna işleyiciyi döndürür.
+   Hiçbir işleyici tanımlanmamışsa &null; döndürülür.
+  </simpara>
+  <simpara>
+   Döndürülen işleyici, tanımlamak için
+   <function>set_exception_handler</function> işlevine iletilen
+   çağrılabilir değerin tam karşılığıdır.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>get_exception_handler</function> örneği</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$handler = function (Throwable $ex) {
+     echo "Exception: " . $ex::class . ": " . $ex->getMessage() . "\n";
+};
+
+var_dump(get_exception_handler()); // NULL
+
+set_exception_handler($handler);
+
+var_dump(get_exception_handler() === $handler); // bool(true)
+
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <tip>
+   <simpara>
+    PHP 8.5.0 öncesinde bu işlevsellik aşağıdaki çokdoldurum ile
+    sağlanabilir:
+   </simpara>
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+if (!function_exists('get_exception_handler')) {
+    function noop_exception_handler() {
+    }
+    function get_exception_handler(): ?callable {
+        $handler = set_exception_handler('noop_exception_handler');
+        restore_exception_handler();
+        return $handler;
+    }
+}
+?>
+]]>
+    </programlisting>
+   </informalexample>
+  </tip>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>set_exception_handler</function></member>
+   <member><function>restore_exception_handler</function></member>
+   <member><function>restore_error_handler</function></member>
+   <member><function>error_reporting</function></member>
+   <member><link linkend="language.exceptions">Exceptions</link></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Add missing Turkish translations for the new PHP 8.5 `get_error_handler()` and `get_exception_handler()` functions.