### PR TITLE
Translate hrtime book

### DIFF
--- a/reference/hrtime/book.xml
+++ b/reference/hrtime/book.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3e7e14916c28630bce69e65f539d27bb96a90066 Maintainer: barisyeman Status: ready -->
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="book.hrtime">
+ <?phpdoc extension-membership="pecl" ?>
+ <title>Yüksek çözünürlüklü zaman ölçümü</title>
+ <titleabbrev>HRTime</titleabbrev>
+
+ <preface xml:id="intro.hrtime">
+  &reftitle.intro;
+  <simpara>
+   HRTime eklentisi yüksek çözünürlüklü bir StopWatch sınıfı gerçekler.
+   Farklı platformlarda mümkün olan en iyi API&apos;leri kullanarak
+   çözünürlüğü nanosaniye mertebesine çıkarır. Ayrıca, temel API&apos;lerin
+   sağladığı düşük seviyeli tick&apos;leri kullanarak özel bir kronometre
+   gerçeklemeye de olanak tanır.
+  </simpara>
+  <note>
+   <simpara>
+    PHP 7.3.0 itibariyle, ilgili <function>hrtime</function> işlevi
+    çekirdeğin bir parçasıdır.
+   </simpara>
+  </note>
+ </preface>
+
+ &reference.hrtime.setup;
+ &reference.hrtime.examples;
+ &reference.hrtime.hrtime.performancecounter;
+ &reference.hrtime.hrtime.stopwatch;
+ &reference.hrtime.hrtime.unit;
+
+</book>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/translation.xml
+++ b/translation.xml
@@ -18,6 +18,8 @@
           nick="aydin"        vcs="no" />
   <person name="Ekin Koç"             email="antimon php.net"
           nick="antimon"      vcs="yes" />
+  <person name="Barış Yeman"          email="info barisyeman.com"
+          nick="barisyeman"   vcs="yes" />
   <person name="Behzat Erte"          email="behzaterte gmail.com"
           nick="behzat"       vcs="no" />
   <person name="Bünyamin Vıcıl"       email="no"


### PR DESCRIPTION
Adds Turkish translation for `reference/hrtime/book.xml` (the HRTime
extension introduction).

Also adds `barisyeman` to the translators list in `translation.xml`.

This is my first contribution to doc-tr. Starting small with a single
file to validate translation style — if the terminology choices are OK,
I plan to continue with the remaining hrtime files (setup, configure,
examples, and the three class references).

EN-Revision used: 3e7e14916c28630bce69e65f539d27bb96a9006