### PR TITLE
[Sync EN] array_map, array_filter, in_array, array_search

### DIFF
--- a/reference/array/functions/array-filter.xml
+++ b/reference/array/functions/array-filter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1de7b5b65f959de3babdd8ea1b060f8cebd60856 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 596c11440dc232b8ed1836d7e3afe2ed5b225a7b Maintainer: nilgun Status: ready -->
 <refentry xml:id="function.array-filter" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_filter</refname>
@@ -252,9 +252,10 @@ array(2) {
   <para>
    <simplelist>
     <member><function>array_intersect</function></member>
+    <member><function>array_find</function></member>
+    <member><function>array_any</function></member>
     <member><function>array_map</function></member>
     <member><function>array_reduce</function></member>
-    <member><function>array_walk</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/array/functions/array-map.xml
+++ b/reference/array/functions/array-map.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 33968dfebb9b847733d02ee221b3b8054a101b41 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 1f5bcc30ee06e452b98362460ea7b7bf2b20f4a1 Maintainer: nilgun Status: ready -->
 <refentry xml:id="function.array-map" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_map</refname>
@@ -40,9 +40,10 @@
       </para>
       <para>
        Çok sayıda diziye bir zip işlemi uygulamak için
-       <parameter>işlev</parameter>'e değer olarak &null; aktarılabilir ve
-       her biri aynı indisin girdi dizilerinin elemanlarını tutan bir dizi
-       döndürür (aşağıdaki örneğe bakın). Sadece <parameter>dizi</parameter>
+       <parameter>işlev</parameter>'e değer olarak &null; aktarılabilir; bu
+       durumda her elemanı, dahili dizi göstergesinin aynı konumundaki girdi
+       dizilerinin elemanlarını içeren bir dizi olan bir dizi döndürülür
+       (aşağıdaki örneğe bakın). Sadece <parameter>dizi</parameter>
        sağlanmışsa, <methodname>array_map</methodname> girilen diziyle döner.
       </para>
      </listitem>
@@ -156,6 +157,7 @@ print_r(array_map(fn($value): int => $value * 2, range(1, 5)));
 ?>
 ]]>
     </programlisting>
+    &example.outputs;
     <screen>
 <![CDATA[
 Array

--- a/reference/array/functions/array-search.xml
+++ b/reference/array/functions/array-search.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 768876982f97b3c710c1774511094e259aea297d Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: nilgun Status: ready -->
 <refentry xml:id="function.array-search" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_search</refname>
@@ -86,7 +86,10 @@
 $array = array(0 => 'blue', 1 => 'red', 2 => 'green', 3 => 'red');
 
 $key = array_search('green', $array); // $key = 2;
+print_r($key);
+
 $key = array_search('red', $array);   // $key = 1;
+print_r($key);
 ?>
 ]]>
     </programlisting>

--- a/reference/array/functions/in-array.xml
+++ b/reference/array/functions/in-array.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8cd7c0d8c574903e149c1da0689a8728cdf909d4 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: nilgun Status: ready -->
 <refentry xml:id="function.in-array" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>in_array</refname>
@@ -156,8 +156,8 @@ if (in_array('o', $a)) {
     &example.outputs;
     <screen>
 <![CDATA[
-  'ph' bulundu
-  'o' bulundu
+'ph' bulundu
+'o' bulundu
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Sync of four widely-used array functions with upstream php/doc-en.

- array_map: refreshed wording about the array pointer in zip mode + missing &example.outputs;
- array_filter: refreshed seealso block (add array_find / array_any)
- in_array: align example screen output indentation
- array_search: print key in example