### PR TITLE
[Sync EN] explode, str_replace, htmlentities, printf

### DIFF
--- a/reference/strings/functions/explode.xml
+++ b/reference/strings/functions/explode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: abd75f51f4daa22d471b0d14114df3886832fb6f Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: nilgun Status: ready -->
 <refentry xml:id="function.explode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>explode</refname>
@@ -127,15 +127,14 @@
 // 1. örnek
 $pizza  = "dilim1 dilim2 dilim3 dilim4 dilim5 dilim6";
 $dilimler = explode(" ", $pizza);
-echo $dilimler[0]; // dilim1
-echo $dilimler[1]; // dilim2
+echo $dilimler[0], PHP_EOL; // dilim1
+echo $dilimler[1], PHP_EOL; // dilim2
 
 // 2. örnek
 $data = "foo:*:1023:1000::/home/foo:/bin/sh";
 list($user, $pass, $uid, $gid, $gecos, $home, $shell) = explode(":", $data);
-echo $user; // foo
-echo $pass; // *
-
+echo $user, PHP_EOL; // foo
+echo $pass, PHP_EOL; // *
 ?>
 ]]>
     </programlisting>

--- a/reference/strings/functions/htmlentities.xml
+++ b/reference/strings/functions/htmlentities.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 840ed22479a110ab63bce0fa75d5f3c41642b8e3 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 06394ea77c2f8972e3884c00bede861ef5eb04da Maintainer: nilgun Status: ready -->
 <refentry xml:id="function.htmlentities" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>htmlentities</refname>
@@ -205,14 +205,20 @@
 <?php
 $str = "<b>Tek</b> bir 'tırnak'";
 
-// Çıktısı: &lt;b&gt;Tek&lt;/b&gt; bir 'tırnak'
 echo htmlentities($str);
-
-// Çıktısı: &lt;b&gt;Tek&lt;/b&gt; bir &#039;quote&#039;
-echo htmlentities($str, ENT_QUOTES);
+echo "\n\n";
+echo htmlentities($str, ENT_COMPAT);
 ?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+&lt;b&gt;Tek&lt;/b&gt; bir &#039;tırnak&#039;
+
+&lt;b&gt;Tek&lt;/b&gt; bir 'tırnak'
+]]>
+    </screen>
    </example>
   </para>
 

--- a/reference/strings/functions/printf.xml
+++ b/reference/strings/functions/printf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 099842f34289b4cf932863e1f83d0e9a144d3b06 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 49999607f48c5e18ef3954a9c6895adbd6aec27a Maintainer: nilgun Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.printf">
  <refnamediv>
   <refname>printf</refname>

--- a/reference/strings/functions/str-replace.xml
+++ b/reference/strings/functions/str-replace.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 464fbf0d12f89b1e723908780fb68acf667f5901 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: nilgun Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.str-replace">
  <refnamediv>
   <refname>str_replace</refname>
@@ -103,10 +103,12 @@
 <?php
 // Sonuç: <body text='black'>
 $bodytag = str_replace("%body%", "black", "<body text='%body%'>");
+echo $bodytag, PHP_EOL;
 
 // Sonuç: Hll Wrld f PHP
 $vowels = array("a", "e", "i", "o", "u", "A", "E", "I", "O", "U");
 $onlyconsonants = str_replace($vowels, "", "Hello World of PHP");
+echo $onlyconsonants, PHP_EOL;
 
 // Sonuç: You should eat pizza, beer, and ice cream every day
 $phrase  = "You should eat fruits, vegetables, and fiber every day.";
@@ -114,10 +116,11 @@ $healthy = array("fruits", "vegetables", "fiber");
 $yummy   = array("pizza", "beer", "ice cream");
 
 $newphrase = str_replace($healthy, $yummy, $phrase);
+echo $newphrase, PHP_EOL;
 
 // sağlanan: 2
 $str = str_replace("ll", "", "good golly miss molly!", $count);
-echo $count;
+echo $count, PHP_EOL;
 ?>
 ]]>
     </programlisting>
@@ -137,6 +140,7 @@ $replace = '<br />';
 
 // \r\n'ler önce değiştirilmeli ki tekrar değiştirilmesin
 $newstr = str_replace($order, $replace, $str);
+echo $newstr, PHP_EOL;
 
 // F çıktılanır, çünkü A ile B, B ile C, ... yer değiştirir.
 // Yer değiştirme soldan sağa doğru yapıldığından
@@ -144,7 +148,7 @@ $newstr = str_replace($order, $replace, $str);
 $search  = array('A', 'B', 'C', 'D', 'E');
 $replace = array('B', 'C', 'D', 'E', 'F');
 $subject = 'A';
-echo str_replace($search, $replace, $subject);
+echo str_replace($search, $replace, $subject), PHP_EOL;
 
 // Çıktısı: apearpearle pear
 // yukarda bahsedilen sebeple
@@ -152,7 +156,7 @@ $letters = array('a', 'p');
 $fruit   = array('apple', 'pear');
 $text    = 'a p';
 $output  = str_replace($letters, $fruit, $text);
-echo $output;
+echo $output, PHP_EOL;
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
Sync of four widely-used string functions with upstream php/doc-en.

- explode: add PHP_EOL between echoes in example
- str_replace: add PHP_EOL between echoes in examples
- htmlentities: refresh example to use ENT_COMPAT, add &example.outputs;
- printf: hash bump (cutoff "8 → 9 characters" comment fix was already correct in TR)