### PR TITLE
[Sync EN] next, prev, current, each

### DIFF
--- a/reference/array/functions/current.xml
+++ b/reference/array/functions/current.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0a192fcd9cc43c0007de795063b4494974058992 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: nilgun Status: ready -->
 <refentry xml:id="function.current" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>current</refname>
@@ -69,13 +69,12 @@
 <![CDATA[
 <?php
 $araç = array('tabanvay', 'bisiklet', 'otomobil', 'uçak');
-$kip = current($araç); // $kip = 'tabanvay';
-$kip = next($araç);    // $kip = 'bisiklet';
-$kip = current($araç); // $kip = 'bisiklet';
-$kip = next($araç);    // $kip = 'otomobil';
-$kip = prev($araç);    // $kip = 'bisiklet';
-$kip = end($araç);     // $kip = 'uçak';
-$kip = current($araç); // $kip = 'uçak';
+echo $kip = current($araç), PHP_EOL; // $kip = 'tabanvay';
+echo $kip = next($araç), PHP_EOL;    // $kip = 'bisiklet';
+echo $kip = current($araç), PHP_EOL; // $kip = 'bisiklet';
+echo $kip = prev($araç), PHP_EOL;    // $kip = 'tabanvay';
+echo $kip = end($araç), PHP_EOL;     // $kip = 'uçak';
+echo $kip = current($araç), PHP_EOL; // $kip = 'uçak';
 
 $arr = array();
 var_dump(current($arr)); // bool(false)

--- a/reference/array/functions/each.xml
+++ b/reference/array/functions/each.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a6655e3f9508eee6860b02f55e33560a790f42d1 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: nilgun Status: ready -->
 <refentry xml:id="function.each" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>each</refname>
@@ -60,7 +60,7 @@
   <para>
    <example>
     <title>- <function>each</function> örnekleri</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $foo = array("bob", "fred", "jussi", "jouni", "egon", "marliese");
@@ -87,7 +87,7 @@ Array
   </para>
   <para>
    <informalexample>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $foo = array("Robert" => "Bob", "Seppo" => "Sepi");
@@ -117,7 +117,7 @@ Array
    <function>list</function> işleviyle birlikte kullanılır. Örnek:
    <example>
     <title>- <function>each</function> ile bir dizinin taranması</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $fruit = array('a' => 'apple', 'b' => 'banana', 'c' => 'cranberry');

--- a/reference/array/functions/next.xml
+++ b/reference/array/functions/next.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9d29b382865dca44919ae9803ef5dfdcbba185fe Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: nilgun Status: ready -->
 <refentry xml:id="function.next" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>next</refname>
@@ -71,11 +71,11 @@
 <![CDATA[
 <?php
 $araç = array('tabanvay', 'bisiklet', 'otomobil', 'uçak');
-$kip = current($araç); // $kip = 'tabanvay';
-$kip = next($araç);    // $kip = 'bisiklet';
-$kip = next($araç);    // $kip = 'otomobil';
-$kip = prev($araç);    // $kip = 'bisiklet';
-$kip = end($araç);     // $kip = 'uçak';
+echo $kip = current($araç), PHP_EOL; // $kip = 'tabanvay';
+echo $kip = next($araç), PHP_EOL;    // $kip = 'bisiklet';
+echo $kip = next($araç), PHP_EOL;    // $kip = 'otomobil';
+echo $kip = prev($araç), PHP_EOL;    // $kip = 'bisiklet';
+echo $kip = end($araç), PHP_EOL;     // $kip = 'uçak';
 ?>
 ]]>
     </programlisting>

--- a/reference/array/functions/prev.xml
+++ b/reference/array/functions/prev.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0a192fcd9cc43c0007de795063b4494974058992 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: nilgun Status: ready -->
 <refentry xml:id="function.prev" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>prev</refname>
@@ -72,11 +72,11 @@
 <![CDATA[
 <?php
 $araç = array('tabanvay', 'bisiklet', 'otomobil', 'uçak');
-$kip = current($araç); // $kip = 'tabanvay';
-$kip = next($araç);    // $kip = 'bisiklet';
-$kip = next($araç);    // $kip = 'otomobil';
-$kip = prev($araç);    // $kip = 'bisiklet';
-$kip = end($araç);     // $kip = 'uçak';
+echo $kip = current($araç), PHP_EOL; // $kip = 'tabanvay';
+echo $kip = next($araç), PHP_EOL;    // $kip = 'bisiklet';
+echo $kip = next($araç), PHP_EOL;    // $kip = 'otomobil';
+echo $kip = prev($araç), PHP_EOL;    // $kip = 'bisiklet';
+echo $kip = end($araç), PHP_EOL;     // $kip = 'uçak';
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
Sync of the four internal-array-pointer functions with upstream php/doc-en:

- next, prev, current: align example with the current EN (use \`echo ..., PHP_EOL;\` so the example actually prints each step)
- each: mark code listings as \`annotations=\"non-interactive\"\` to match EN