### PR TITLE
[Sync EN] strlen, strstr, strcasecmp, strncasecmp

### DIFF
--- a/reference/strings/functions/strcasecmp.xml
+++ b/reference/strings/functions/strcasecmp.xml
@@ -47,7 +47,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  &strings.comparison.return;
+  <simpara>
+   <parameter>dizge1</parameter> dizgesi <parameter>dizge2</parameter>
+   dizgesinden küçükse 0'dan küçük bir değer; <parameter>dizge1</parameter>
+   dizgesi <parameter>dizge2</parameter> dizgesinden büyükse 0'dan büyük
+   bir değer; eşitseler <literal>0</literal> döndürür.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/strings/functions/strcasecmp.xml
+++ b/reference/strings/functions/strcasecmp.xml
@@ -47,12 +47,14 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <simpara>
+  <para>
    <parameter>dizge1</parameter> dizgesi <parameter>dizge2</parameter>
-   dizgesinden küçükse 0'dan küçük bir değer; <parameter>dizge1</parameter>
-   dizgesi <parameter>dizge2</parameter> dizgesinden büyükse 0'dan büyük
-   bir değer; eşitseler <literal>0</literal> döndürür.
-  </simpara>
+   dizgesinden küçükse <literal>-1</literal>;
+   <parameter>dizge1</parameter> dizgesi <parameter>dizge2</parameter>
+   dizgesinden büyükse <literal>1</literal>;
+   <parameter>dizge1</parameter> dizgesi ile <parameter>dizge2</parameter>
+   dizgesi aynıysa <literal>0</literal> döndürür.
+  </para>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/strings/functions/strcasecmp.xml
+++ b/reference/strings/functions/strcasecmp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a3573c18b89fd32aca1c3924d3fd9568900b4a33 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 9b68bf2b63200534e022bc65e800cae6c75abf26 Maintainer: nilgun Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.strcasecmp">
  <refnamediv>
   <refname>strcasecmp</refname>
@@ -47,14 +47,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   <parameter>dizge1</parameter> dizgesi <parameter>dizge2</parameter>
-   dizgesinden küçükse <literal>-1</literal>;
-   <parameter>dizge1</parameter> dizgesi <parameter>dizge2</parameter>
-   dizgesinden büyükse <literal>1</literal>;
-   <parameter>dizge1</parameter> dizgesi ile <parameter>dizge2</parameter>
-   dizgesi aynıysa <literal>0</literal> döndürür.
-  </para>
+  &strings.comparison.return;
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/strings/functions/strlen.xml
+++ b/reference/strings/functions/strlen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: af30c6e8acc1e90b9c4a4f44539d4215d51370ab Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: nilgun Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.strlen">
  <refnamediv>
   <refname>strlen</refname>
@@ -49,10 +49,10 @@
 <![CDATA[
 <?php
 $str = 'abcdef';
-echo strlen($str); // 6
+echo strlen($str), PHP_EOL; // 6
 
 $str = ' ab cd ';
-echo strlen($str); // 7
+echo strlen($str), PHP_EOL; // 7
 ?>
 ]]>
     </programlisting>

--- a/reference/strings/functions/strncasecmp.xml
+++ b/reference/strings/functions/strncasecmp.xml
@@ -55,7 +55,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  &strings.comparison.return;
+  <simpara>
+   <parameter>dizge1</parameter> dizgesi <parameter>dizge2</parameter>
+   dizgesinden küçükse 0'dan küçük bir değer; <parameter>dizge1</parameter>
+   dizgesi <parameter>dizge2</parameter> dizgesinden büyükse 0'dan büyük
+   bir değer; eşitseler <literal>0</literal> döndürür.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/strings/functions/strncasecmp.xml
+++ b/reference/strings/functions/strncasecmp.xml
@@ -55,12 +55,14 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <simpara>
+  <para>
    <parameter>dizge1</parameter> dizgesi <parameter>dizge2</parameter>
-   dizgesinden küçükse 0'dan küçük bir değer; <parameter>dizge1</parameter>
-   dizgesi <parameter>dizge2</parameter> dizgesinden büyükse 0'dan büyük
-   bir değer; eşitseler <literal>0</literal> döndürür.
-  </simpara>
+   dizgesinden küçükse <literal>-1</literal>;
+   <parameter>dizge1</parameter> dizgesi <parameter>dizge2</parameter>
+   dizgesinden büyükse <literal>1</literal>;
+   <parameter>dizge1</parameter> dizgesi ile <parameter>dizge2</parameter>
+   dizgesi aynıysa <literal>0</literal> döndürür.
+  </para>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/strings/functions/strncasecmp.xml
+++ b/reference/strings/functions/strncasecmp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a3573c18b89fd32aca1c3924d3fd9568900b4a33 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 9b68bf2b63200534e022bc65e800cae6c75abf26 Maintainer: nilgun Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.strncasecmp">
  <refnamediv>
   <refname>strncasecmp</refname>
@@ -55,14 +55,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   <parameter>dizge1</parameter> dizgesi <parameter>dizge2</parameter>
-   dizgesinden küçükse <literal>-1</literal>;
-   <parameter>dizge1</parameter> dizgesi <parameter>dizge2</parameter>
-   dizgesinden büyükse <literal>1</literal>;
-   <parameter>dizge1</parameter> dizgesi ile <parameter>dizge2</parameter>
-   dizgesi aynıysa <literal>*</literal> döndürür.
-  </para>
+  &strings.comparison.return;
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/strings/functions/strstr.xml
+++ b/reference/strings/functions/strstr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c276fff86c44bc92a9f9105aa66342a731ac78d8 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: nilgun Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.strstr">
  <refnamediv>
   <refname>strstr</refname>
@@ -120,10 +120,10 @@
 <?php
 $email  = 'name@example.com';
 $domain = strstr($email, '@');
-echo $domain; // @example.com basar
+echo $domain, PHP_EOL; // @example.com basar
 
 $user = strstr($email, '@', true);
-echo $user; // name basar
+echo $user, PHP_EOL; // name basar
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
Sync of four widely-used string functions with upstream php/doc-en:

- strlen, strstr: add PHP_EOL between echoes in examples (so the example actually prints something distinct each step)
- strcasecmp, strncasecmp: use the shared \`&strings.comparison.return;\` entity for return values, which also fixes a stale '*' typo in strncasecmp.