### PR TITLE
[Translate] array_first, array_last

### DIFF
--- a/reference/array/functions/array-first.xml
+++ b/reference/array/functions/array-first.xml
@@ -13,7 +13,7 @@
    <methodparam><type>array</type><parameter>dizi</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Belirtilen <parameter>dizi</parameter>nin ilk değerini döndürür.
+   Belirtilen <parameter>dizi</parameter>nin ilk değeri ile döner.
   </simpara>
  </refsect1>
 

--- a/reference/array/functions/array-first.xml
+++ b/reference/array/functions/array-first.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: b68b5e427e7454a59437dd6f7ff27b4f9228fe6d Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.array-first" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>array_first</refname>
+  <refpurpose>Dizinin ilk değeri ile döner</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>array_first</methodname>
+   <methodparam><type>array</type><parameter>dizi</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Belirtilen <parameter>dizi</parameter>nin ilk değerini döndürür.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>dizi</parameter></term>
+    <listitem>
+     <simpara>
+      Bir dizi.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Dizi boş değilse <parameter>dizi</parameter>nin ilk değeri ile döner;
+   aksi takdirde &null; döner.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="array_first.example.basic">
+   <title>- <function>array_first</function> Temel Kullanım Örneği</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$dizi = [1 => 'a', 0 => 'b', 3 => 'c', 2 => 'd'];
+
+$ilkDeger = array_first($dizi);
+
+var_dump($ilkDeger);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+string(1) "a"
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>array_key_first</function></member>
+   <member><function>array_last</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/array/functions/array-last.xml
+++ b/reference/array/functions/array-last.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: b68b5e427e7454a59437dd6f7ff27b4f9228fe6d Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.array-last" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>array_last</refname>
+  <refpurpose>Dizinin son değeri ile döner</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>array_last</methodname>
+   <methodparam><type>array</type><parameter>dizi</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Belirtilen <parameter>dizi</parameter>nin son değerini döndürür.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>dizi</parameter></term>
+    <listitem>
+     <simpara>
+      Bir dizi.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Dizi boş değilse <parameter>dizi</parameter>nin son değeri ile döner;
+   aksi takdirde &null; döner.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="array_last.example.basic">
+   <title>- <function>array_last</function> Temel Kullanım Örneği</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$dizi = [1 => 'a', 0 => 'b', 3 => 'c', 2 => 'd'];
+
+$sonDeger = array_last($dizi);
+
+var_dump($sonDeger);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+string(1) "d"
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>array_key_last</function></member>
+   <member><function>array_first</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/array/functions/array-last.xml
+++ b/reference/array/functions/array-last.xml
@@ -13,7 +13,7 @@
    <methodparam><type>array</type><parameter>dizi</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Belirtilen <parameter>dizi</parameter>nin son değerini döndürür.
+   Belirtilen <parameter>dizi</parameter>nin son değeri ile döner.
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
Translate the two PHP 8.5 array helpers into Turkish, completing the series started in #41 (array_find, array_find_key, array_any, array_all). Wording and example structure aligned with the existing array_key_first / array_key_last pages.