### PR TITLE
[Translate] mb_trim, mb_ltrim, mb_rtrim

### DIFF
--- a/reference/mbstring/functions/mb-ltrim.xml
+++ b/reference/mbstring/functions/mb-ltrim.xml
@@ -15,14 +15,46 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>kodlama</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Çok baytlı güvenli bir <function>ltrim</function> işlemi gerçekleştirir.
-   Dizgenin başındaki boşlukları (veya diğer karakterleri) budar.
+   Çok baytlı kodlamalar için güvenli bir <function>ltrim</function> işlemi
+   gerçekleştirir. Dizgenin başındaki boşlukları (veya diğer karakterleri)
+   budar.
   </simpara>
   <simpara>
    İkinci bağımsız değişken belirtilmediğinde
    <function>mb_ltrim</function> şu karakterleri budar:
   </simpara>
-  &strings.stripped.unicode;
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <literal>" "</literal> (<acronym>Unicode</acronym> U+0020), sıradan boşluk.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>"\t"</literal> (<acronym>Unicode</acronym> U+0009), sekme.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>"\n"</literal> (<acronym>Unicode</acronym> U+000A), satırsonu.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>"\r"</literal> (<acronym>Unicode</acronym> U+000D), satırbaşı.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>"\0"</literal> (<acronym>Unicode</acronym> U+0000), <literal>NUL</literal>-bayt.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>"\v"</literal> (<acronym>Unicode</acronym> U+000B), dikey sekme.
+    </simpara>
+   </listitem>
+  </itemizedlist>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -39,7 +71,12 @@
    <varlistentry>
     <term><parameter>karakterler</parameter></term>
     <listitem>
-     &strings.parameter.unicode.optional;
+     <simpara>
+      Seçimlik olarak, <parameter>karakterler</parameter> bağımsız değişkeni
+      kullanılarak budanacak karakterler belirlenebilir. Basitçe budamak
+      istenen tüm karakterler belirtilir. Bir karakter aralığını
+      <literal>..</literal> kullanarak belirtmek de mümkündür.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/mbstring/functions/mb-ltrim.xml
+++ b/reference/mbstring/functions/mb-ltrim.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 154d938992a7ccec7febb3c6f2366bd262dac388 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.mb-ltrim" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>mb_ltrim</refname>
+  <refpurpose>Dizgenin başındaki boşlukları (veya diğer karakterleri) budar</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>mb_ltrim</methodname>
+   <methodparam><type>string</type><parameter>dizge</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>karakterler</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>kodlama</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Çok baytlı güvenli bir <function>ltrim</function> işlemi gerçekleştirir.
+   Dizgenin başındaki boşlukları (veya diğer karakterleri) budar.
+  </simpara>
+  <simpara>
+   İkinci bağımsız değişken belirtilmediğinde
+   <function>mb_ltrim</function> şu karakterleri budar:
+  </simpara>
+  &strings.stripped.unicode;
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>dizge</parameter></term>
+    <listitem>
+     <simpara>
+      Girdi dizgesi.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>karakterler</parameter></term>
+    <listitem>
+     &strings.parameter.unicode.optional;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>kodlama</parameter></term>
+    <listitem>
+     &mbstring.encoding.parameter;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Bu işlev <parameter>dizge</parameter>nin başındaki boşluklar budanmış bir
+   dizge döndürür.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>mb_trim</function></member>
+   <member><function>mb_rtrim</function></member>
+   <member><function>ltrim</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mbstring/functions/mb-rtrim.xml
+++ b/reference/mbstring/functions/mb-rtrim.xml
@@ -15,15 +15,46 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>kodlama</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Çok baytlı güvenli bir <function>rtrim</function> işlemi gerçekleştirir
-   ve <parameter>dizge</parameter>nin sonundaki boşluklar (veya diğer
-   karakterler) budanmış bir dizge döndürür.
+   Çok baytlı kodlamalar için güvenli bir <function>rtrim</function> işlemi
+   gerçekleştirir ve <parameter>dizge</parameter>nin sonundaki boşluklar
+   (veya diğer karakterler) budanmış bir dizge döndürür.
   </simpara>
   <simpara>
    İkinci bağımsız değişken belirtilmediğinde
    <function>mb_rtrim</function> şu karakterleri budar:
   </simpara>
-  &strings.stripped.unicode;
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <literal>" "</literal> (<acronym>Unicode</acronym> U+0020), sıradan boşluk.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>"\t"</literal> (<acronym>Unicode</acronym> U+0009), sekme.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>"\n"</literal> (<acronym>Unicode</acronym> U+000A), satırsonu.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>"\r"</literal> (<acronym>Unicode</acronym> U+000D), satırbaşı.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>"\0"</literal> (<acronym>Unicode</acronym> U+0000), <literal>NUL</literal>-bayt.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>"\v"</literal> (<acronym>Unicode</acronym> U+000B), dikey sekme.
+    </simpara>
+   </listitem>
+  </itemizedlist>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -40,7 +71,12 @@
    <varlistentry>
     <term><parameter>karakterler</parameter></term>
     <listitem>
-     &strings.parameter.unicode.optional;
+     <simpara>
+      Seçimlik olarak, <parameter>karakterler</parameter> bağımsız değişkeni
+      kullanılarak budanacak karakterler belirlenebilir. Basitçe budamak
+      istenen tüm karakterler belirtilir. Bir karakter aralığını
+      <literal>..</literal> kullanarak belirtmek de mümkündür.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/mbstring/functions/mb-rtrim.xml
+++ b/reference/mbstring/functions/mb-rtrim.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 154d938992a7ccec7febb3c6f2366bd262dac388 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.mb-rtrim" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>mb_rtrim</refname>
+  <refpurpose>Dizgenin sonundaki boşlukları (veya diğer karakterleri) budar</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>mb_rtrim</methodname>
+   <methodparam><type>string</type><parameter>dizge</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>karakterler</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>kodlama</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Çok baytlı güvenli bir <function>rtrim</function> işlemi gerçekleştirir
+   ve <parameter>dizge</parameter>nin sonundaki boşluklar (veya diğer
+   karakterler) budanmış bir dizge döndürür.
+  </simpara>
+  <simpara>
+   İkinci bağımsız değişken belirtilmediğinde
+   <function>mb_rtrim</function> şu karakterleri budar:
+  </simpara>
+  &strings.stripped.unicode;
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>dizge</parameter></term>
+    <listitem>
+     <simpara>
+      Girdi dizgesi.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>karakterler</parameter></term>
+    <listitem>
+     &strings.parameter.unicode.optional;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>kodlama</parameter></term>
+    <listitem>
+     &mbstring.encoding.parameter;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Değiştirilmiş dizge ile döner.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>mb_trim</function></member>
+   <member><function>mb_ltrim</function></member>
+   <member><function>rtrim</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/mbstring/functions/mb-trim.xml
+++ b/reference/mbstring/functions/mb-trim.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 154d938992a7ccec7febb3c6f2366bd262dac388 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.mb-trim" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>mb_trim</refname>
+  <refpurpose>Dizgenin başındaki ve sonundaki boşlukları (veya diğer karakterleri) budar</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>mb_trim</methodname>
+   <methodparam><type>string</type><parameter>dizge</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>karakterler</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>kodlama</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Çok baytlı güvenli bir <function>trim</function> işlemi gerçekleştirir ve
+   <parameter>dizge</parameter>nin başındaki ve sonundaki boşluklar budanmış
+   bir dizge döndürür. İkinci bağımsız değişken belirtilmediğinde
+   <function>mb_trim</function> şu karakterleri budar:
+  </simpara>
+  &strings.stripped.unicode;
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>dizge</parameter></term>
+    <listitem>
+     <simpara>
+      Budanacak <type>string</type>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>karakterler</parameter></term>
+    <listitem>
+     &strings.parameter.unicode.optional;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>kodlama</parameter></term>
+    <listitem>
+     &mbstring.encoding.parameter;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Budanmış dizge.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>mb_ltrim</function></member>
+   <member><function>mb_rtrim</function></member>
+   <member><function>trim</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mbstring/functions/mb-trim.xml
+++ b/reference/mbstring/functions/mb-trim.xml
@@ -15,12 +15,43 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>kodlama</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Çok baytlı güvenli bir <function>trim</function> işlemi gerçekleştirir ve
-   <parameter>dizge</parameter>nin başındaki ve sonundaki boşluklar budanmış
-   bir dizge döndürür. İkinci bağımsız değişken belirtilmediğinde
-   <function>mb_trim</function> şu karakterleri budar:
+   Çok baytlı kodlamalar için güvenli bir <function>trim</function> işlemi
+   gerçekleştirir ve <parameter>dizge</parameter>nin başındaki ve sonundaki
+   boşluklar budanmış bir dizge döndürür. İkinci bağımsız değişken
+   belirtilmediğinde <function>mb_trim</function> şu karakterleri budar:
   </simpara>
-  &strings.stripped.unicode;
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <literal>" "</literal> (<acronym>Unicode</acronym> U+0020), sıradan boşluk.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>"\t"</literal> (<acronym>Unicode</acronym> U+0009), sekme.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>"\n"</literal> (<acronym>Unicode</acronym> U+000A), satırsonu.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>"\r"</literal> (<acronym>Unicode</acronym> U+000D), satırbaşı.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>"\0"</literal> (<acronym>Unicode</acronym> U+0000), <literal>NUL</literal>-bayt.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>"\v"</literal> (<acronym>Unicode</acronym> U+000B), dikey sekme.
+    </simpara>
+   </listitem>
+  </itemizedlist>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -37,7 +68,12 @@
    <varlistentry>
     <term><parameter>karakterler</parameter></term>
     <listitem>
-     &strings.parameter.unicode.optional;
+     <simpara>
+      Seçimlik olarak, <parameter>karakterler</parameter> bağımsız değişkeni
+      kullanılarak budanacak karakterler belirlenebilir. Basitçe budamak
+      istenen tüm karakterler belirtilir. Bir karakter aralığını
+      <literal>..</literal> kullanarak belirtmek de mümkündür.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>


### PR DESCRIPTION
Translate the three PHP 8.4 multibyte trim helpers into Turkish, aligned with the existing trim / ltrim / rtrim wording (\"budar\", \"dizge\", \"karakterler\", \"kodlama\"), and reusing the shared entities (strings.stripped.unicode, strings.parameter.unicode.optional, mbstring.encoding.parameter).