### PR TITLE
[Translate] mb_lcfirst, mb_ucfirst

### DIFF
--- a/reference/mbstring/functions/mb-lcfirst.xml
+++ b/reference/mbstring/functions/mb-lcfirst.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 154d938992a7ccec7febb3c6f2366bd262dac388 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.mb-lcfirst" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>mb_lcfirst</refname>
+  <refpurpose>Dizgenin ilk karakterini küçük harfe çevirir</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>mb_lcfirst</methodname>
+   <methodparam><type>string</type><parameter>dizge</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>kodlama</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Çok baytlı kodlamalar için güvenli bir <function>lcfirst</function> işlemi
+   gerçekleştirir ve <parameter>dizge</parameter>nin ilk karakteri küçük
+   harfe çevrilmiş bir dizge döndürür.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>dizge</parameter></term>
+    <listitem>
+     <simpara>
+      Girdi dizgesi.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>kodlama</parameter></term>
+    <listitem>
+     &mbstring.encoding.parameter;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Sonuç dizgesi ile döner.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>mb_ucfirst</function></member>
+   <member><function>lcfirst</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/mbstring/functions/mb-ucfirst.xml
+++ b/reference/mbstring/functions/mb-ucfirst.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 154d938992a7ccec7febb3c6f2366bd262dac388 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.mb-ucfirst" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>mb_ucfirst</refname>
+  <refpurpose>Dizgenin ilk karakterini büyük harfe çevirir</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>mb_ucfirst</methodname>
+   <methodparam><type>string</type><parameter>dizge</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>kodlama</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Çok baytlı kodlamalar için güvenli bir <function>ucfirst</function> işlemi
+   gerçekleştirir ve <parameter>dizge</parameter>nin ilk karakteri büyük
+   harfe çevrilmiş bir dizge döndürür.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>dizge</parameter></term>
+    <listitem>
+     <simpara>
+      Girdi dizgesi.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>kodlama</parameter></term>
+    <listitem>
+     &mbstring.encoding.parameter;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Sonuç dizgesi ile döner.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    <function>strtolower</function> ve <function>strtoupper</function> gibi
+    standart harf büyüklüğü değiştirme işlevlerinin aksine, bu işlemde harf
+    büyüklüğü değişimi Unicode karakter özelliklerine göre yapılır.
+    Bu nedenle bu işlevin davranışı yerel ayarlarından etkilenmez ve
+    'alfabetik' özelliğe sahip her karakteri (örneğin a-umlaut, ä)
+    dönüştürebilir.
+   </para>
+  </note>
+  <para>
+   Unicode karakter özellikleri hakkında daha ayrıntılı bilgi için bakınız:
+   <link xlink:href="&url.unicode.reports;">&url.unicode.reports;</link>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>mb_lcfirst</function></member>
+   <member><function>mb_convert_case</function></member>
+   <member><function>ucfirst</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->


### PR DESCRIPTION
Translate the two PHP 8.4 multibyte case helpers into Turkish, completing the mbstring 8.4 series merged in #46. Wording aligned with the existing lcfirst / ucfirst pages and the phrasing already accepted in #46. mb_ucfirst includes the Unicode notes section and the seealso to mb_convert_case to mirror the EN page.