### PR TITLE
[Translate] mb_str_pad

### DIFF
--- a/reference/mbstring/functions/mb-str-pad.xml
+++ b/reference/mbstring/functions/mb-str-pad.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e4e09f45c91ede64c7b7834eda71e4dfcdd3fd85 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.mb-str-pad" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>mb_str_pad</refname>
+  <refpurpose>Çok baytlı bir dizgeyi belli bir uzunlukta diğer bir çok baytlı dizgeyle doldurur</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>mb_str_pad</methodname>
+   <methodparam><type>string</type><parameter>dizge</parameter></methodparam>
+   <methodparam><type>int</type><parameter>uzunluk</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>dolgu_dizgesi</parameter><initializer>" "</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>dolgu_türü</parameter><initializer><constant>STR_PAD_RIGHT</constant></initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>kodlama</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Bu işlev <parameter>dizge</parameter> değiştirgesini, uzunluğu Unicode kod
+   konumları cinsinden ölçülen belirtilen dolgu uzunluğuna kadar solundan,
+   sağından veya her iki tarafından doldurarak döndürür. Seçimlik
+   <parameter>dolgu_dizgesi</parameter> değiştirgesi belirtilmezse,
+   <parameter>dizge</parameter> boşluk karakterleriyle doldurulur, aksi
+   takdirde sınıra kadar <parameter>dolgu_dizgesi</parameter> içindeki
+   karakterlerle doldurulur.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>dizge</parameter></term>
+     <listitem>
+      <para>
+       Girdi dizgesi.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>uzunluk</parameter></term>
+     <listitem>
+      <para>
+       <parameter>uzunluk</parameter> değeri negatifse, girdi dizgesinin
+       uzunluğundan küçük veya ona eşitse herhangi bir dolgu işlemi yapılmaz
+       ve <parameter>dizge</parameter> döndürülür.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>dolgu_dizgesi</parameter></term>
+     <listitem>
+      <note>
+       <para>
+        Gerekli dolgu karakterlerinin sayısı
+        <parameter>dolgu_dizgesi</parameter> uzunluğuna tam olarak
+        bölünemiyorsa <parameter>dolgu_dizgesi</parameter> kırpılabilir.
+       </para>
+      </note>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>dolgu_türü</parameter></term>
+     <listitem>
+      <para>
+       Seçimlik <parameter>dolgu_türü</parameter> değiştirgesi olarak
+       <constant>STR_PAD_RIGHT</constant> (sağ),
+       <constant>STR_PAD_LEFT</constant> (sol) veya
+       <constant>STR_PAD_BOTH</constant> (her iki taraf) belirtilebilir.
+       <constant>STR_PAD_RIGHT</constant> değeri öntanımlıdır.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>kodlama</parameter></term>
+     <listitem>
+      &mbstring.encoding.parameter;
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Dolgulu dizge döner.
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>mb_str_pad</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(mb_str_pad('▶▶', 6, '❤❓❇', STR_PAD_RIGHT)); // string(18) "▶▶❤❓❇❤"
+var_dump(mb_str_pad('▶▶', 6, '❤❓❇', STR_PAD_LEFT));  // string(18) "❤❓❇❤▶▶"
+var_dump(mb_str_pad('▶▶', 6, '❤❓❇', STR_PAD_BOTH));  // string(18) "❤❓▶▶❤❓"
+
+var_dump(mb_str_pad("🎉", 3, "祝", STR_PAD_LEFT));   // string(10) "祝祝🎉"
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/translation.xml
+++ b/translation.xml
@@ -38,6 +38,8 @@
           nick="flarecaster"  vcs="yes" />
   <person name="Yücel Haluk Bugüner"  email="haluk.buguner gmail.com"
           nick="haluk"        vcs="no" />
+  <person name="Louis-Arnaud Catoire"  email="la.catoire gmail.com"
+          nick="lacatoire"    vcs="yes" />
   <person name="Mesut Tunga"          email="mesut tunga.com"
           nick="mesut"        vcs="no" />
   <person name="Mustafa Aldemir"      email="no"


### PR DESCRIPTION
Çeviri: `mb_str_pad` (mbstring uzantısı), `str_pad` çevirisinin biçemini izler.

Ayrıca #47 üzerindeki @nilgun isteği üzerine `translation.xml` içine `lacatoire` eklendi.