### PR TITLE
[Sync EN] mb_decode_numericentity, mb_encode_numericentity

### DIFF
--- a/reference/mbstring/functions/mb-decode-numericentity.xml
+++ b/reference/mbstring/functions/mb-decode-numericentity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 92f1b8b177eb5730382abf9f27bae868f1bb636f Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 4e69a9f2b14deefca0befec576335e33152448f3 Maintainer: nilgun Status: ready -->
 <refentry xml:id="function.mb-decode-numericentity" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_decode_numericentity</refname>
@@ -69,6 +69,14 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   <parameter>bölge</parameter> bir tamsayı listesi değilse bir
+   <exceptionname>ValueError</exceptionname> yavrulanır.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -80,6 +88,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <function>mb_decode_numericentity</function>, <parameter>bölge</parameter>
+       bir tamsayı listesi değilse artık bir
+       <exceptionname>ValueError</exceptionname> yavruluyor.
+      </entry>
+     </row>
      &mbstring.changelog.encoding-nullable;
     </tbody>
    </tgroup>
@@ -97,7 +113,7 @@
 $bölge = array (
  int kodlama_başı1, int kodlama_sonu1, int göreli_konum1, int maske1,
  int kodlama_başı2, int kodlama_sonu2, int göreli_konum2, int maske2,
- ........
+ // ........
  int kodlama_başıN, int kodlama_sonuN, int göreli_konumN, int maskeN );
 // kodlama_başıN ve int kodlama_sonuN için Evrenkodlu değer belirt,
 // değere göreli_konumN ekleyip sonucu maskeN ile bitsel VE'le ve

--- a/reference/mbstring/functions/mb-encode-numericentity.xml
+++ b/reference/mbstring/functions/mb-encode-numericentity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a3db55f0df6a17d473f65ce207ef3f778011cdfe Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: a60ef65239113c7871643be68ada91081376c936 Maintainer: nilgun Status: ready -->
 <refentry xml:id="function.mb-encode-numericentity" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_encode_numericentity</refname>
@@ -68,6 +68,14 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   <parameter>bölge</parameter> bir tamsayı listesi değilse bir
+   <exceptionname>ValueError</exceptionname> yavrulanır.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -79,6 +87,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <function>mb_encode_numericentity</function>, <parameter>bölge</parameter>
+       bir tamsayı listesi değilse artık bir
+       <exceptionname>ValueError</exceptionname> yavruluyor.
+      </entry>
+     </row>
      &mbstring.changelog.encoding-nullable;
     </tbody>
    </tgroup>
@@ -116,27 +132,29 @@ $bölge = array (
     <programlisting role="php">
 <![CDATA[
 <?php
-/* ISO-8859-1'in sol tarafını HTML sayısal karakter gösterimine dönüştürelim */
-$bölge = array(0x80, 0xff, 0, 0xff);
-$dizge = mb_encode_numericentity($dizge, $bölge, "ISO-8859-1");
 
-/* Kullanıcı tanımlı SJIS-win'i 95-104 aralığında sayısal gösterime
-   dönüştürelim */
-$bölge = array(
-       0xe000, 0xe03e, 0x1040, 0xffff,
-       0xe03f, 0xe0bb, 0x1041, 0xffff,
-       0xe0bc, 0xe0fa, 0x1084, 0xffff,
-       0xe0fb, 0xe177, 0x1085, 0xffff,
-       0xe178, 0xe1b6, 0x10c8, 0xffff,
-       0xe1b7, 0xe233, 0x10c9, 0xffff,
-       0xe234, 0xe272, 0x110c, 0xffff,
-       0xe273, 0xe2ef, 0x110d, 0xffff,
-       0xe2f0, 0xe32e, 0x1150, 0xffff,
-       0xe32f, 0xe3ab, 0x1151, 0xffff );
-$dizge = mb_encode_numericentity($dizge, $bölge, "sjis-win");
+$dizge = "aAæÆあア𩸽";
+
+/* 4 bayta kadar tüm UTF8 karakterlerini HTML sayısal karakter gösterimine dönüştürür */
+$bölge = [0, 0x1FFFFF, 0, 0x10FFFF];
+var_dump(mb_encode_numericentity($dizge, $bölge, "utf8"));
+
+/* Yalnızca 2 baytlık ve 4 baytlık UTF8 karakterlerini HTML sayısal karakter gösterimine dönüştürür */
+$bölge = [
+    0x80, 0x7FF, 0, 0x10FFFF,
+    0x10000, 0x1FFFFF, 0, 0x10FFFF,
+];
+var_dump(mb_encode_numericentity($dizge, $bölge, "utf8"));
 ?>
 ]]>
     </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+string(46) "&#97;&#65;&#230;&#198;&#12354;&#12450;&#40509;"
+string(28) "aA&#230;&#198;あア&#40509;"
+]]>
+   </screen>
    </example>
   </para>
  </refsect1>


### PR DESCRIPTION
EN ile eşitleme: `mb_decode_numericentity` ve `mb_encode_numericentity` (mbstring), `errors` bölümü, 8.4.0 changelog ve örnek güncellemeleri.