### PR TITLE
[Sync EN] strpos, stripos, strrpos, strripos

### DIFF
--- a/reference/strings/functions/stripos.xml
+++ b/reference/strings/functions/stripos.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 71b1e926631d5f5bec9b2e2685553453349ae799 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 4b72b23513caa3a8bc520d459a0417defc7b3880 Maintainer: nilgun Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.stripos">
  <refnamediv>
   <refname>stripos</refname>
@@ -71,6 +71,19 @@
   &return.falseproblem;
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     Eğer <parameter>başlangıç</parameter> değeri
+     <parameter>samanlık</parameter> uzunluğundan büyükse, bir
+     <classname>ValueError</classname> yavrulanır.
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -126,13 +139,13 @@ $pos2 = stripos($mystring2, $findme);
 
 // 'a' kesinlikle 'xyz' içinde yoktur
 if ($pos1 === false) {
-  echo "'$mystring1' dizgesinde '$findme' dizgesi yok";
+  echo "'$mystring1' dizgesinde '$findme' dizgesi yok", PHP_EOL;
 }
 
-// 'a' 0. karakter olduğundan == işleci beklendiği gibi
-// çalışmayacaktır. Bu yüzden === kullanmaya çalışın.
+// !== işlecinin kullanımına dikkat. != işleci beklendiği gibi
+// çalışmayacaktır çünkü 'a' 0. (ilk) karakterdedir.
 if ($pos2 !== false) {
-  echo "'$mystring1' dizgesinin $pos2. karakterinde bir '$findme' dizgesi var";
+  echo "'$mystring1' dizgesinin $pos2. karakterinde bir '$findme' dizgesi var", PHP_EOL;
 }
 ?>
 ]]>

--- a/reference/strings/functions/strpos.xml
+++ b/reference/strings/functions/strpos.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7efec4c29a3cb6d6e7abe325a3c0d5b6024fa37c Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 4b72b23513caa3a8bc520d459a0417defc7b3880 Maintainer: nilgun Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.strpos">
  <refnamediv>
   <refname>strpos</refname>
@@ -70,6 +70,19 @@
    Eğer <parameter>iğne</parameter> bulunamazsa &false; döner.
   </para>
   &return.falseproblem;
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     Eğer <parameter>başlangıç</parameter> değeri
+     <parameter>samanlık</parameter> uzunluğundan büyükse, bir
+     <classname>ValueError</classname> yavrulanır.
+    </simpara>
+   </listitem>
+  </itemizedlist>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -165,6 +178,8 @@ if ($konum !== false) {
 // Belli bir konumdan önceki herşeyi yoksayarak bir karakteri arayabiliriz
 $samanlık = 'abcdef abcdef';
 $konum = strpos($samanlık, 'a', 1); // $konum = 7 olur, 0 değil
+
+echo $konum, PHP_EOL;
 ?>
 ]]>
     </programlisting>

--- a/reference/strings/functions/strripos.xml
+++ b/reference/strings/functions/strripos.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 71b1e926631d5f5bec9b2e2685553453349ae799 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: nilgun Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.strripos">
  <refnamediv>
   <refname>strripos</refname>
@@ -89,6 +89,19 @@
   &return.falseproblem;
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     Eğer <parameter>başlangıç</parameter> değeri
+     <parameter>samanlık</parameter> uzunluğundan büyükse, bir
+     <classname>ValueError</classname> yavrulanır.
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -131,17 +144,19 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+
 $samanlık = 'ababcd';
 $iğne   = 'aB';
 
 $konum      = strripos($samanlık, $iğne);
 
 if ($konum === false) {
-    echo "($samanlık) içinde ($iğne) bulunamadı";
+    echo "`$samanlık` içinde `$iğne` bulunamadı";
 } else {
     echo "Tebrikler!\n";
-    echo "($samanlık) içindeki son ($iğne) ($konum) konumunda bulundu";
+    echo "`$samanlık` içindeki son `$iğne` `$konum` konumunda bulundu";
 }
+
 ?>
 ]]>
     </programlisting>
@@ -149,7 +164,7 @@ if ($konum === false) {
     <screen>
 <![CDATA[
 Tebrikler!
-(ababcd) içindeki son (aB) (2) konumunda bulundu
+`ababcd` içindeki son `aB` `2` konumunda bulundu
 ]]>
     </screen>
    </example>

--- a/reference/strings/functions/strrpos.xml
+++ b/reference/strings/functions/strrpos.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2eb2cdbe58d2f35cb88ad06fa090f3c0ccd9f860 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 4b72b23513caa3a8bc520d459a0417defc7b3880 Maintainer: nilgun Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.strrpos">
  <refnamediv>
   <refname>strrpos</refname>
@@ -84,6 +84,19 @@
   &return.falseproblem;
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     Eğer <parameter>başlangıç</parameter> değeri
+     <parameter>samanlık</parameter> uzunluğundan büyükse, bir
+     <classname>ValueError</classname> yavrulanır.
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -129,6 +142,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+$mystring = 'Elephpant';
 
 $pos = strrpos($mystring, "b");
 if ($pos === false) { // üçlü eşittire dikkat


### PR DESCRIPTION
EN ile eşitleme: `strpos`, `stripos`, `strrpos`, `strripos` (strings), `errors` bölümü ve örnek güncellemeleri.