### PR TITLE
[Sync EN] var: print_r, serialize, var_export, unset, is_null, is_bool

### DIFF
--- a/reference/var/functions/is-bool.xml
+++ b/reference/var/functions/is-bool.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: d816a0fad6c458d9515f697cc89e26ca9d8069f5 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.is-bool" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>is_bool</refname>
@@ -50,12 +50,12 @@ $b = 0;
 
 // $a mantıksal türde olduğundan true döner
 if (is_bool($a) === true) {
-    echo "Evet, bu bir mantıksal değerdir";
+    echo "Evet, bu bir mantıksal değerdir\n";
 }
 
 // $b mantıksal türde olmadığından true dönmez
 if (is_bool($b) === false) {
-    echo "Hayır, bu bir mantıksal değer değildir";
+    echo "Hayır, bu bir mantıksal değer değildir\n";
 }
 ?>
 ]]>

--- a/reference/var/functions/is-null.xml
+++ b/reference/var/functions/is-null.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: d816a0fad6c458d9515f697cc89e26ca9d8069f5 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.is-null" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>is_null</refname>
@@ -55,16 +55,10 @@ var_dump(is_null($inexistent), is_null($foo));
 ?>
 ]]>
     </programlisting>
-    <screen>
-<![CDATA[
-Notice: Undefined variable: inexistent in ...
-bool(true)
-bool(true)
-]]>
-    </screen>
    </example>
   </para>
  </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/var/functions/print-r.xml
+++ b/reference/var/functions/print-r.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ccc438a27bae31d71fe2ca7dc095360db5bc1af6 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: d816a0fad6c458d9515f697cc89e26ca9d8069f5 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.print-r" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>print_r</refname>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type class="union"><type>string</type><type>bool</type></type><methodname>print_r</methodname>
+   <type class="union"><type>string</type><type>true</type></type><methodname>print_r</methodname>
    <methodparam><type>mixed</type><parameter>ifade</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>döndür</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
@@ -71,6 +71,32 @@
    </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Dönüş türü <type class="union"><type>string</type><type>bool</type></type>
+        türünden <type class="union"><type>string</type><type>true</type></type>
+        türüne değiştirildi.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -81,7 +107,7 @@
 <pre>
 <?php
 $a = array ('a' => 'apple', 'b' => 'banana', 'c' => array ('x', 'y', 'z'));
-print_r ($a);
+print_r($a);
 ?>
 </pre>
 ]]>
@@ -114,6 +140,8 @@ Array
 <?php
 $b = array ('m' => 'monkey', 'foo' => 'bar', 'x' => array ('x', 'y', 'z'));
 $results = print_r($b, true); // $results print_r çıktısını içerir
+
+print_r($results);
 ?>
 ]]>
     </programlisting>

--- a/reference/var/functions/serialize.xml
+++ b/reference/var/functions/serialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8cdc6621f9826d04abc3e50438c010804d7e8683 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: d816a0fad6c458d9515f697cc89e26ca9d8069f5 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.serialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>serialize</refname>
@@ -84,7 +84,7 @@
   <para>
    <example>
     <title>- <function>serialize</function> örneği</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // $session_data, geçerli kullanıcı için oturum bilgisini

--- a/reference/var/functions/unset.xml
+++ b/reference/var/functions/unset.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f30ccc6aa0dabe411c52305202fe85209ddc06b Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: d816a0fad6c458d9515f697cc89e26ca9d8069f5 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.unset" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>unset</refname>
-  <refpurpose>Belirtilen değişkeni bildirimsiz yapar</refpurpose>
+  <refpurpose>Belirtilen değişkeni <function>unset</function> ile bildirimsiz yapar</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -26,8 +26,8 @@
    içinde küreselleştirilmiş bir değişken olup değişkenin sadece yerel tanımı
    yok edilir. Değişkenin çağrı ortamındaki değeri <function>unset</function>
    çağrılmadan önceki değerini korur.
-  </para>
-   <informalexample>
+   <example>
+    <title><function>unset</function> kullanımı</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -43,20 +43,13 @@ echo $foo;
 ?>
 ]]>
     </programlisting>
-   </informalexample>
-  &example.outputs;
-   <informalexample>
-    <screen>
-<![CDATA[
-bar
-]]>
-    </screen>
-   </informalexample>
+   </example>
+  </para>
   <para>
    Bir küresel değişkeni bir işlev içinde yoketmeniz gerekliyse
    <varname>$GLOBALS</varname> dizisini kullanabilirsiniz:
-  </para>
-   <informalexample>
+   <example>
+    <title>Bir küresel değişkenin <function>unset</function> ile yokedilmesi</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -70,14 +63,15 @@ foo();
 ?>
 ]]>
     </programlisting>
-   </informalexample>
+   </example>
+  </para>
   <para>
    Gönderimli aktarılan bir değişkeni bir işlev içinde yoketmeye çalışırsanız
    sadece yerel değişkeni yoketmiş olursunuz. Değişkenin, işlevin çağrıldıgı
    ortamdaki değeri <function>unset</function> çağrılmadan önceki değerini
    korur.
-  </para>
-   <informalexample>
+   <example>
+    <title>Gönderim ile <function>unset</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -95,22 +89,14 @@ echo "$bar\n";
 ?>
 ]]>
     </programlisting>
-   </informalexample>
-   &example.outputs;
-   <informalexample>
-    <screen>
-<![CDATA[
-bir şey
-bir şey
-]]>
-    </screen>
-   </informalexample>
+   </example>
+  </para>
   <para>
    Bir duruk değişkeni bir işlev içinde yoketmeye çalışırsanız
    değişkeni sadece işlevin kalan bağlamı için yoketmiş olursunuz. Aşağıdaki
    çağrılar değişkenin önceki değerinin geçerli kaldığını gösterecektir.
-  </para>
-   <informalexample>
+   <example>
+    <title>Duruk değişkenle <function>unset</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -130,17 +116,8 @@ foo();
 ?>
 ]]>
     </programlisting>
-   </informalexample>
-   &example.outputs;
-   <informalexample>
-    <screen>
-<![CDATA[
-unset öncesi: 1, unset sonrası: 23
-unset öncesi: 2, unset sonrası: 23
-unset öncesi: 3, unset sonrası: 23
-]]>
-    </screen>
-   </informalexample>
+   </example>
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -179,7 +156,7 @@ unset öncesi: 3, unset sonrası: 23
   <para>
    <example>
     <title>- <function>unset</function> örneği</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // tek bir değişkeni yokedelim
@@ -193,35 +170,6 @@ unset($foo1, $foo2, $foo3);
 ?>
 ]]>
     </programlisting>
-   </example>
-   <example>
-    <title>- (unset) - &null;'a dönüşüm örneği</title>
-    <para>
-     <link linkend="language.types.null.casting"><literal>(unset)</literal></link>
-     dönüşümü çoğunlukla <function>unset</function> işlevi ile karıştırılır.
-     <literal>(unset)</literal> dönüşümü bütünlük adına, sadece
-     <literal>NULL</literal> döndürür, dönüşüm yaptığı değişkene &null;
-     atamaz, yani işlev gibi değişkeni bildirimsiz yapmaz.
-     <literal>(unset)</literal> dönüşümünün kullanımı PHP 7.2.0
-     ve sonrasında önerilmemekte olup 8.0.0'da kullanımdan kaldırılmıştır.
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-$name = 'Felipe';
-
-var_dump((unset) $name);
-var_dump($name);
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-NULL
-string(6) "Felipe"
-]]>
-    </screen>
    </example>
   </para>
  </refsect1>

--- a/reference/var/functions/var-export.xml
+++ b/reference/var/functions/var-export.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0f27fadf81b66268edf545f13891401b4d53cc38 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: d816a0fad6c458d9515f697cc89e26ca9d8069f5 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.var-export" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>var_export</refname>
@@ -179,7 +179,7 @@ var_export($a);
     &example.outputs;
     <screen>
 <![CDATA[
-A::__set_state(array(
+\A::__set_state(array(
    'var' => 5,
 ))
 ]]>


### PR DESCRIPTION
Sync six widely-used `var` reference files to EN HEAD `d816a0f` (Enable WASM for book.var, and tweak examples).

`print_r` also picks up the PHP 8.4 return-type changelog (`string|bool` → `string|true`); `unset` mirrors the EN refactor of `<informalexample>` blocks into titled `<example>` blocks with the trailing `<screen>` outputs removed (now executed live by WASM) and drops the removed `(unset)` cast example.

Glossary and corpus respected.