### PR TITLE
[Sync EN] datetime: date, time, mktime, microtime, gmdate, getdate

### DIFF
--- a/reference/datetime/functions/date.xml
+++ b/reference/datetime/functions/date.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: lacatoire Status: ready -->
+<!-- CREDITS: behzat -->
 <refentry xml:id="function.date" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>date</refname>

--- a/reference/datetime/functions/date.xml
+++ b/reference/datetime/functions/date.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d94400847cec608f93830aa85e0761b97d7cb9bf Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.date" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>date</refname>
@@ -107,21 +107,20 @@ date_default_timezone_set('UTC');
 
 
 // Şöyle bir şey basar: Monday
-echo date("l");
+echo date("l") . "\n";
 
 // Şöyle bir şey basar: Monday 8th of August 2005 03:12:46 PM
-echo date('l jS \of F Y h:i:s A');
+echo date('l jS \of F Y h:i:s A') . "\n";
 
 // Şöyle bir şey basar: July 1, 2000 is on a Saturday
-echo "July 1, 2000 is on a " . date("l", mktime(0, 0, 0, 7, 1, 2000));
+echo "July 1, 2000 is on a " . date("l", mktime(0, 0, 0, 7, 1, 2000)) . "\n";
 
 /* biçim bağımsız değişkeni için sabit kullanımı*/
 // Şöyle bir şey basar: Wed, 25 Sep 2013 15:28:57 -0700
-echo date(DATE_RFC2822);
+echo date(DATE_RFC2822) . "\n";
 
 // Şöyle bir şey basar: 2000-07-01T00:00:00+00:00
 echo date(DATE_ATOM, mktime(0, 0, 0, 7, 1, 2000));
-?>
 ]]>
     </programlisting>
    </example>
@@ -138,34 +137,9 @@ echo date(DATE_ATOM, mktime(0, 0, 0, 7, 1, 2000));
 <?php
 // Şöyle bir şey basar: Wednesday the 15th
 echo date('l \t\h\e jS');
-?>
 ]]>
     </programlisting>
    </example>
-  </para>
-  <para>
-   <function>date</function> ve <function>mktime</function> işlevleri
-   birlikte, geçmiş ya da gelecek zamanın bulunmasında kullanılabilir.
-   <example>
-    <title>- <function>date</function> ve <function>mktime</function> örneği
-    </title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-$yarın  = mktime(0, 0, 0, date("m")  , date("d")+1, date("Y"));
-$geçenay = mktime(0, 0, 0, date("m")-1, date("d"),   date("Y"));
-$gelecekyıl = mktime(0, 0, 0, date("m"),   date("d"),   date("Y")+1);
-?>
-]]>
-    </programlisting>
-   </example>
-   <note>
-    <para>
-     Bu kullanım, yaz saati uygulamasından dolayı, bir zaman damgasına
-     basitçe saniye, gün ve ay ekleme veya çıkartma işlemlerinden daha
-     güvenilirdir.
-    </para>
-   </note>
   </para>
   <para>
    Bazı <function>date</function> işlevi biçimlendirme örnekleri. Diğer
@@ -181,18 +155,18 @@ $gelecekyıl = mktime(0, 0, 0, date("m"),   date("d"),   date("Y")+1);
 <?php
 // Bugünün; March 10th, 2001, 5:16:18 pm olduğunu ve
 // Mountain Standard Time (MST) Zaman Diliminde olduğumuzu varsayıyoruz
+date_default_timezone_set("America/Phoenix");
 
-$bugün = date("F j, Y, g:i a");                 // March 10, 2001, 5:16 pm
-$bugün = date("m.d.y");                         // 03.10.01
-$bugün = date("j, n, Y");                       // 10, 3, 2001
-$bugün = date("Ymd");                           // 20010310
-$bugün = date('h-i-s, j-m-y, it is w Day');     // 05-16-18, 10-03-01, 1631 1618 6 Satpm01
-$bugün = date('\i\t \i\s \t\h\e jS \d\a\y.');   // it is the 10th day.
-$bugün = date("D M j G:i:s T Y");               // Sat Mar 10 17:16:18 MST 2001
-$bugün = date('H:m:s \m \i\s\ \m\o\n\t\h');     // 17:03:18 m is month
-$bugün = date("H:i:s");                         // 17:16:18
-$bugün = date("Y-m-d H:i:s");                   // 2001-03-10 17:16:18 (MySQL DATETIME biçimi)
-?>
+echo date("F j, Y, g:i a") . "\n";                 // March 10, 2001, 5:16 pm
+echo date("m.d.y") . "\n";                         // 03.10.01
+echo date("j, n, Y") . "\n";                       // 10, 3, 2001
+echo date("Ymd") . "\n";                           // 20010310
+echo date('h-i-s, j-m-y, it is w Day') . "\n";     // 05-16-18, 10-03-01, 1631 1618 6 Satpm01
+echo date('\i\t \i\s \t\h\e jS \d\a\y.') . "\n";   // it is the 10th day.
+echo date("D M j G:i:s T Y") . "\n";               // Sat Mar 10 17:16:18 MST 2001
+echo date('H:m:s \m \i\s\ \m\o\n\t\h') . "\n";     // 17:03:18 m is month
+echo date("H:i:s") . "\n";                         // 17:16:18
+echo date("Y-m-d H:i:s") . "\n";                   // 2001-03-10 17:16:18 (MySQL DATETIME biçimi)
 ]]>
     </programlisting>
    </example>

--- a/reference/datetime/functions/getdate.xml
+++ b/reference/datetime/functions/getdate.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: lacatoire Status: ready -->
+<!-- CREDITS: behzat -->
 
 <refentry xml:id="function.getdate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/datetime/functions/getdate.xml
+++ b/reference/datetime/functions/getdate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 34188f8256bdc6f0e6e1965c2be94247997165b6 Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.getdate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -160,7 +160,6 @@
 <?php
 $bugun = getdate();
 print_r($bugun);
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
@@ -170,15 +169,15 @@ Array
 (
     [seconds] => 40
     [minutes] => 58
-    [hours]   => 21
-    [mday]    => 17
-    [wday]    => 2
-    [mon]     => 6
-    [year]    => 2003
-    [yday]    => 167
+    [hours] => 21
+    [mday] => 17
+    [wday] => 2
+    [mon] => 6
+    [year] => 2003
+    [yday] => 167
     [weekday] => Salı
-    [month]   => Haziran
-    [0]       => 1055901520
+    [month] => Haziran
+    [0] => 1055901520
 )
 ]]>
     </screen>

--- a/reference/datetime/functions/gmdate.xml
+++ b/reference/datetime/functions/gmdate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5c951013ca04161992efed8b86fb40f55669958e Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.gmdate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmdate</refname>
@@ -73,18 +73,22 @@
   <para>
    <example>
     <title>- <function>gmdate</function> örneği</title>
-    <para>
-     Aşağıdaki betik Türkiye'de (GMT +0200) çalıştırılsaydı ilk çıktı "01 Oca
-     1998 00:00:00", ikinci çıktı "31 Ara 1997 22:00:00" olurdu.
-    </para>
     <programlisting role="php">
 <![CDATA[
 <?php
-echo date("d M Y H:i:s", mktime(0, 0, 0, 1, 1, 1998));
-echo gmdate("d M Y H:i:s", mktime(0, 0, 0, 1, 1, 1998));
-?>
+date_default_timezone_set("Europe/Helsinki");
+
+echo date("M d Y H:i:s e", mktime(0, 0, 0, 1, 1, 1998)) . "\n";
+echo gmdate("M d Y H:i:s e", mktime(0, 0, 0, 1, 1, 1998));
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Jan 01 1998 00:00:00 Europe/Helsinki
+Dec 31 1997 22:00:00 UTC
+]]>
+    </screen>
    </example>
   </para>
  </refsect1>

--- a/reference/datetime/functions/gmdate.xml
+++ b/reference/datetime/functions/gmdate.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: lacatoire Status: ready -->
+<!-- CREDITS: behzat -->
 <refentry xml:id="function.gmdate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmdate</refname>

--- a/reference/datetime/functions/microtime.xml
+++ b/reference/datetime/functions/microtime.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: lacatoire Status: ready -->
+<!-- CREDITS: behzat -->
 <refentry xml:id="function.microtime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>microtime</refname>

--- a/reference/datetime/functions/microtime.xml
+++ b/reference/datetime/functions/microtime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5c951013ca04161992efed8b86fb40f55669958e Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.microtime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>microtime</refname>
@@ -68,30 +68,28 @@
 $sure_baslangici = microtime(true);
 
 // Biraz bekle
-usleep(100);
+usleep(10_000);
 
 $sure_bitimi = microtime(true);
 $sure = $sure_bitimi - $sure_baslangici;
 
-echo "Bekleme süresi: $sure saniye.\n";
-?>
+print "Bekleme süresi: $sure saniye.\n";
 ]]>
     </programlisting>
    </example>
    <example>
     <title><function>microtime</function> and <literal>REQUEST_TIME_FLOAT</literal> </title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // Uyuma süresi için rasgele sayı üret
-usleep(mt_rand(100, 10000));
+usleep(random_int(10_000, 1_000_000));
 
 // REQUEST_TIME_FLOAT $_SERVER süper küresel dizisinde bulunur.
 // Mikrosaniyelik doğrulukta isteğin zaman damgasını içerir
 $time = microtime(true) - $_SERVER["REQUEST_TIME_FLOAT"];
 
 echo "$time saniyede hiçbir şey olmadı.\n";
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 349e3c6502e0bbeb15aef2b4a4a25f3f5e10fbfe Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.mktime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mktime</refname>
@@ -179,14 +179,20 @@
 // Öntanımlı zaman dilimini belirtelim.
 date_default_timezone_set('UTC');
 
-echo "July 1, 2000 is on a " . date("l", mktime(0, 0, 0, 7, 1, 2000));
+echo "July 1, 2000 is on a " . date("l", mktime(0, 0, 0, 7, 1, 2000)) . "\n";
 // Çıktısı: July 1, 2000 is on a Saturday
 
-echo date('c', mktime(1, 2, 3, 4, 5, 2006));
+echo date('c', mktime(1, 2, 3, 4, 5, 2006)) . "\n";
 // Şöyle bir şey basar: 2006-04-05T01:02:03+00:00
-?>
 ]]>
     </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+July 1, 2000 is on a Saturday
+2006-04-05T01:02:03+00:00
+]]>
+    </screen>
    </example>
   </para>
   <para>
@@ -201,14 +207,59 @@ echo date('c', mktime(1, 2, 3, 4, 5, 2006));
     <programlisting role="php">
 <![CDATA[
 <?php
-echo date("M-d-Y", mktime(0, 0, 0, 12, 32, 1997));
-echo date("M-d-Y", mktime(0, 0, 0, 13, 1, 1997));
-echo date("M-d-Y", mktime(0, 0, 0, 1, 1, 1998));
-echo date("M-d-Y", mktime(0, 0, 0, 1, 1, 98));
-?>
+date_default_timezone_set('America/New_York');
+
+echo date("c", mktime(0, 0, 0, 12, 32, 1997)) . "\n";
+echo date("c", mktime(0, 0, 0, 13, 1, 1997)) . "\n";
+echo date("c", mktime(0, 0, 0, 1, 1, 1998)) . "\n";
+echo date("c", mktime(0, 0, 0, 1, 1, 98)) . "\n";
 ]]>
     </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+1998-01-01T00:00:00-05:00
+1998-01-01T00:00:00-05:00
+1998-01-01T00:00:00-05:00
+1998-01-01T00:00:00-05:00
+]]>
+    </screen>
    </example>
+  </para>
+  <para>
+   <example>
+    <title>Bağıl tarihleri bulmak için <function>mktime</function> kullanımı</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+date_default_timezone_set('Asia/Tokyo');
+
+$yarın  = mktime(0, 0, 0, date("m")  , date("d")+1, date("Y"));
+print date('c', $yarın) . "\n";
+
+$geçenay = mktime(0, 0, 0, date("m")-1, date("d"),   date("Y"));
+print date('c', $geçenay) . "\n";
+
+$gelecekyıl  = mktime(0, 0, 0, date("m"),   date("d"),   date("Y")+1) . "\n";
+print date('c', $gelecekyıl) . "\n";
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+2025-09-30T00:00:00+09:00
+2025-08-29T00:00:00+09:00
+2026-09-29T00:00:00+09:00
+]]>
+    </screen>
+   </example>
+   <note>
+    <para>
+     Bu kullanım, yaz saati uygulamasından dolayı, bir zaman damgasına
+     basitçe saniye, gün ve ay ekleme veya çıkartma işlemlerinden daha
+     güvenilirdir.
+    </para>
+   </note>
   </para>
   <para>
    <example>
@@ -220,13 +271,21 @@ echo date("M-d-Y", mktime(0, 0, 0, 1, 1, 98));
     <programlisting role="php">
 <![CDATA[
 <?php
+
 $songün = mktime(0, 0, 0, 3, 0, 2000);
-echo "2000 Şubat'ının son günü: ", date('d', $songün);
+echo "2000 Şubat'ının son günü: ", date('d', $songün) . "\n";
+
 $songün = mktime(0, 0, 0, 4, -31, 2000);
-echo "2000 Şubat'ının son günü: ", date('d', $songün);
-?>
+echo "2000 Şubat'ının son günü: ", date('d', $songün) . "\n";
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+2000 Şubat'ının son günü: 29
+2000 Şubat'ının son günü: 29
+]]>
+    </screen>
    </example>
   </para>
  </refsect1>

--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: lacatoire Status: ready -->
+<!-- CREDITS: behzat -->
 <refentry xml:id="function.mktime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mktime</refname>

--- a/reference/datetime/functions/time.xml
+++ b/reference/datetime/functions/time.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"  encoding="utf-8"?>
 <!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: lacatoire Status: ready -->
+<!-- CREDITS: behzat -->
 <refentry xml:id="function.time" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>time</refname>

--- a/reference/datetime/functions/time.xml
+++ b/reference/datetime/functions/time.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"  encoding="utf-8"?>
-<!-- EN-Revision: 5c951013ca04161992efed8b86fb40f55669958e Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.time" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>time</refname>
@@ -47,7 +47,6 @@
 <![CDATA[
 <?php
 echo 'Şimdi: '. time();
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;


### PR DESCRIPTION
Sync six core `datetime` reference files to EN HEAD `3a8c3e7` (Enable runnable WASM examples for datetime, #4887).

`mktime` and `date` get a bit more than the others: `date.xml` drops the `date()`/`mktime()` "find dates in future or past" example which moved over to `mktime.xml` as a new "Bağıl tarihleri bulmak için mktime kullanımı" example, with the DST note tagging along; `mktime.xml` also picks up explicit `<screen>` outputs for the now-runnable examples.

Glossary and corpus respected.