### PR TITLE
[Translate] filter_list, filter_id, filter_has_var

### DIFF
--- a/reference/filter/functions/filter-has-var.xml
+++ b/reference/filter/functions/filter-has-var.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 627f933cfe6a033dccac32982cd68e7c1b86927f Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.filter-has-var">
+ <refnamediv>
+  <refname>filter_has_var</refname>
+  <refpurpose>Belirtilen türde bir değişkenin mevcut olup olmadığına bakar</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>filter_has_var</methodname>
+   <methodparam><type>int</type><parameter>tür</parameter></methodparam>
+   <methodparam><type>string</type><parameter>değişken_ismi</parameter></methodparam>
+  </methodsynopsis>
+
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>tür</parameter></term>
+    <listitem>
+     <para>
+      <constant>INPUT_GET</constant>, <constant>INPUT_POST</constant>,
+      <constant>INPUT_COOKIE</constant>, <constant>INPUT_SERVER</constant>
+      veya <constant>INPUT_ENV</constant> sabitlerinden biri.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>değişken_ismi</parameter></term>
+    <listitem>
+     <para>
+      Sınanacak değişkenin ismi.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/filter/functions/filter-id.xml
+++ b/reference/filter/functions/filter-id.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 627f933cfe6a033dccac32982cd68e7c1b86927f Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.filter-id">
+ <refnamediv>
+  <refname>filter_id</refname>
+  <refpurpose>İsimlendirilmiş bir süzgece ait süzgeç kimliğini döndürür</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>filter_id</methodname>
+   <methodparam><type>string</type><parameter>isim</parameter></methodparam>
+  </methodsynopsis>
+
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>isim</parameter></term>
+    <listitem>
+     <para>
+      Kimliği alınacak süzgecin ismi.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Başarı durumunda süzgecin kimliğini, süzgeç mevcut değilse &false;
+   döndürür.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>filter_list</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/filter/functions/filter-list.xml
+++ b/reference/filter/functions/filter-list.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 627f933cfe6a033dccac32982cd68e7c1b86927f Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.filter-list">
+ <refnamediv>
+  <refname>filter_list</refname>
+  <refpurpose>Desteklenen tüm süzgeçlerin listesini döndürür</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>filter_list</methodname>
+   <void/>
+  </methodsynopsis>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Desteklenen tüm süzgeçlerin isimlerini içeren bir dizi döndürür, böyle
+   süzgeçler yoksa boş bir dizi döndürür. Bu dizinin indisleri süzgeç
+   kimlikleri değildir; süzgeç kimlikleri bir isimden hareketle
+   <function>filter_id</function> işlevi ile elde edilebilir.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Bir <function>filter_list</function> örneği</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+print_r(filter_list());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Array
+(
+    [0] => int
+    [1] => boolean
+    [2] => float
+    [3] => validate_regexp
+    [4] => validate_url
+    [5] => validate_email
+    [6] => validate_ip
+    [7] => string
+    [8] => stripped
+    [9] => encoded
+    [10] => special_chars
+    [11] => unsafe_raw
+    [12] => email
+    [13] => url
+    [14] => number_int
+    [15] => number_float
+    [16] => magic_quotes
+    [17] => callback
+)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Add Turkish translations for three previously untranslated `filter` reference functions, all introduced upstream on 2026-01-16 (commit `627f933`).

Parameter naming follows the convention already in use in `filter-input.xml` (`tür`, `değişken_ismi`); glossary and corpus respected.