### PR TITLE
[Translate] random: rand, mt_rand, mt_srand, lcg_value, getrandmax, mt_getrandmax

### DIFF
--- a/reference/random/functions/getrandmax.xml
+++ b/reference/random/functions/getrandmax.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 2166824858a40ea664c558f2930b63b8f4fd89c6 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.getrandmax" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>getrandmax</refname>
+  <refpurpose>Olası en büyük rastgele değeri döndürür</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+   <methodsynopsis>
+    <type>int</type><methodname>getrandmax</methodname>
+    <void/>
+   </methodsynopsis>
+  <simpara>
+   <function>rand</function> çağrısı tarafından döndürülebilecek azami
+   değeri döndürür.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <function>rand</function> tarafından döndürülen olası en büyük rastgele
+   değer.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>rand</function></member>
+    <member><function>srand</function></member>
+    <member><function>mt_getrandmax</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/random/functions/lcg-value.xml
+++ b/reference/random/functions/lcg-value.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.lcg-value" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>lcg_value</refname>
+  <refpurpose>Birleşik doğrusal eşleşik üreteç</refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-4-0;
+ </refsynopsisdiv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
+   <type>float</type><methodname>lcg_value</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   <function>lcg_value</function> işlevi (0, 1) aralığında bir sözde rastgele
+   sayı döndürür. İşlev, 2^31 - 85 ve 2^31 - 249 periyotlu iki CG'yi
+   birleştirir. Bu işlevin periyodu, bu iki asal sayının çarpımına eşittir.
+  </para>
+  &caution.cryptographically-insecure;
+  <caution>
+   <para>
+    Dönüş değerini çarpma veya toplama (yani bir afin dönüşüm) kullanarak
+    farklı bir aralığa ölçeklemek, gerçek sayılar sayı doğrusu boyunca eşit
+    yoğunlukta olmadığından sonuç değerinde sapmalara yol açabilir. Tüm
+    değerler bir gerçek sayı ile tam olarak ifade edilemediğinden, afin
+    dönüşümün sonucu istenen aralığın dışındaki değerlere de yol açabilir.
+   </para>
+   <para>
+    Keyfi bir aralık içinde rastgele bir gerçek sayı üretmek için
+    <methodname>Random\Randomizer::getFloat</methodname> kullanılabilir.
+    Keyfi bir aralık içinde rastgele bir tamsayı üretmek için
+    <methodname>Random\Randomizer::getInt</methodname> kullanılabilir.
+   </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   0.0 ve 1.0 dahil, aralarındaki bir sözde rastgele gerçek sayı değeri.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Bu işlevin kullanımı önerilmemekte.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Random\Randomizer::getFloat</methodname></member>
+    <member><methodname>Random\Randomizer::getInt</methodname></member>
+    <member><function>random_int</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/random/functions/mt-getrandmax.xml
+++ b/reference/random/functions/mt-getrandmax.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c174b16add554508aafdd40c5d3f2997099882b6 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.mt-getrandmax" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>mt_getrandmax</refname>
+  <refpurpose>Olası en büyük rastgele değeri döndürür</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+   <methodsynopsis>
+    <type>int</type><methodname>mt_getrandmax</methodname>
+    <void/>
+   </methodsynopsis>
+  <simpara>
+   <function>mt_rand</function> çağrısı tarafından döndürülebilecek azami
+   değeri döndürür.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Bağımsız değişkensiz <function>mt_rand</function> çağrısı tarafından
+   döndürülen azami rastgele değeri döndürür. Bu değer, sonuç ölçeklenmeden
+   (ve dolayısıyla daha az rastgele olmadan) <parameter>azami</parameter>
+   bağımsız değişkeni için kullanılabilecek azami değerdir.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>mt_rand</function></member>
+    <member><function>mt_srand</function></member>
+    <member><function>getrandmax</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/random/functions/mt-rand.xml
+++ b/reference/random/functions/mt-rand.xml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: d6dc2be3c5c70e4a1c3d13f788643ea232747c19 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.mt-rand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>mt_rand</refname>
+  <refpurpose>Mersenne Twister Rastgele Sayı Üreteci ile rastgele bir değer üretir</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>mt_rand</methodname>
+   <void/>
+  </methodsynopsis>
+  <methodsynopsis>
+   <type>int</type><methodname>mt_rand</methodname>
+   <methodparam><type>int</type><parameter>asgari</parameter></methodparam>
+   <methodparam><type>int</type><parameter>azami</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Eski libc'lerin pek çok rastgele sayı üreteci, şüpheli ya da bilinmeyen
+   özelliklere sahiptir ve yavaştır. <function>mt_rand</function> işlevi,
+   eski <function>rand</function> işlevinin yerine doğrudan kullanılabilen
+   bir karşılığıdır. <link xlink:href="&url.mersenne;">Mersenne Twister</link>
+   kullanan, bilinen özelliklere sahip bir rastgele sayı üreteci kullanır.
+   Bu üreteç, ortalama bir libc rand() işlevinden dört kat daha hızlı
+   rastgele sayı üretir.
+  </simpara>
+  <simpara>
+   Seçimlik <parameter>asgari</parameter> ve <parameter>azami</parameter>
+   bağımsız değişkenleri olmaksızın çağrıldığında
+   <function>mt_rand</function>, 0 ile <function>mt_getrandmax</function>
+   arasında bir sözde rastgele değer döndürür. Örneğin, 5 ile 15 (dahil)
+   arasında rastgele bir sayı isteniyorsa <literal>mt_rand(5, 15)</literal>
+   kullanılabilir.
+  </simpara>
+  &caution.cryptographically-insecure;
+  &caution.mt19937-global-state;
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>asgari</parameter></term>
+     <listitem>
+      <para>
+       Döndürülecek seçimlik en küçük değer (öntanımlı: 0)
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>azami</parameter></term>
+     <listitem>
+      <para>
+       Döndürülecek seçimlik en büyük değer
+       (öntanımlı: <function>mt_getrandmax</function>)
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>asgari</parameter> (veya 0) ile <parameter>azami</parameter>
+   (veya <function>mt_getrandmax</function>, dahil) arasında rastgele bir
+   tamsayı değeri.
+  </para>
+ </refsect1>
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <parameter>azami</parameter>, <parameter>asgari</parameter>
+     değerinden küçükse bir <classname>ValueError</classname> istisnası
+     yavrulanır.
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </refsect1>
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <parameter>azami</parameter>, <parameter>asgari</parameter>
+       değerinden küçükse bir <classname>ValueError</classname> istisnası
+       yavrulanır; önceden <constant>E_WARNING</constant> uyarısı
+       üretiliyor ve işlev &false; döndürüyordu.
+      </entry>
+     </row>
+      <row>
+       <entry>7.2.0</entry>
+       <entry>
+        <function>mt_rand</function>, modulo sapma hatası için
+        <link linkend="migration72.incompatible.rand-mt_rand-output">bir hata düzeltmesi aldı</link>.
+        Bu, belirli bir tohumla üretilen dizilerin, 64 bitlik makinelerde
+        PHP 7.1'den farklı olabileceği anlamına gelir.
+       </entry>
+      </row>
+      <row>
+       <entry>7.1.0</entry>
+       <entry>
+        <function>rand</function> işlevi <function>mt_rand</function>
+        işlevinin <link linkend="migration71.incompatible.rand-srand-aliases">takma adı haline getirildi</link>.
+       </entry>
+      </row>
+      <row>
+       <entry>7.1.0</entry>
+       <entry>
+        <function>mt_rand</function> işlevi, Mersenne Twister algoritmasının
+        sabitlenmiş, doğru sürümünü kullanmak üzere
+        <link linkend="migration71.incompatible.fixes-to-mt_rand-algorithm">güncellendi</link>.
+        Eski davranışa geri dönmek için ikinci bağımsız değişken olarak
+        <constant>MT_RAND_PHP</constant> ile <function>mt_srand</function>
+        kullanılabilir.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>mt_rand</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+echo mt_rand(), "\n";
+echo mt_rand(), "\n";
+
+echo mt_rand(5, 15), "\n";
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+1604716014
+1478613278
+6
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <warning>
+   <para>
+    <parameter>asgari</parameter> <parameter>azami</parameter> aralığı
+    <function>mt_getrandmax</function> aralığı içinde olmalıdır. Yani
+    (<parameter>azami</parameter> - <parameter>asgari</parameter>) &lt;=
+    <function>mt_getrandmax</function>. Aksi takdirde,
+    <function>mt_rand</function> olması gerekenden daha düşük kaliteli
+    rastgele sayılar döndürebilir.
+   </para>
+  </warning>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>mt_srand</function></member>
+    <member><function>mt_getrandmax</function></member>
+    <member><function>random_int</function></member>
+    <member><function>random_bytes</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/random/functions/mt-srand.xml
+++ b/reference/random/functions/mt-srand.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 9eb92e5c1851d7838ba02e88e7a0e5bb5c86880a Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.mt-srand" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>mt_srand</refname>
+  <refpurpose>Mersenne Twister Rastgele Sayı Üretecini tohumlar</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>mt_srand</methodname>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>tohum</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>kip</parameter><initializer><constant>MT_RAND_MT19937</constant></initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Rastgele sayı üretecini <parameter>tohum</parameter> ile, ya da
+   <parameter>tohum</parameter> belirtilmemişse rastgele bir değerle
+   tohumlar.
+  </para>
+
+  &note.randomseed;
+  &caution.mt19937-tiny-seed;
+
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>tohum</parameter></term>
+     <listitem>
+      <para>
+       İçsel durumu, işaretsiz 32 bit tamsayı olarak yorumlanan
+       <parameter>tohum</parameter> ile tohumlanmış bir doğrusal eşleşik
+       üretecin ürettiği değerlerle doldurur.
+      </para>
+      <para>
+       <parameter>tohum</parameter> belirtilmemişse veya &null; ise,
+       rastgele bir işaretsiz 32 bit tamsayı kullanılır.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>kip</parameter></term>
+     <listitem>
+      <para>
+       Kullanılacak algoritmanın gerçeklenimini belirtmek için aşağıdaki
+       sabitlerden biri kullanılır.
+       <simplelist>
+        <member>
+         <constant>MT_RAND_MT19937</constant>:
+         PHP 7.1.0'dan itibaren mevcut olan doğru Mt19937 gerçeklenimi.
+        </member>
+        <member>
+         <constant>MT_RAND_PHP</constant>
+         PHP 7.1.0'a kadar öntanımlı olarak kullanılan, hatalı bir
+         Mersenne Twister gerçeklenimini kullanır. Bu kip, geriye dönük
+         uyumluluk için mevcuttur.
+        </member>
+       </simplelist>
+      </para>
+      &warn.deprecated.feature-8-3-0;
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.3.0</entry>
+       <entry>
+        <parameter>tohum</parameter> artık &null; olabiliyor.
+       </entry>
+      </row>
+      <row>
+       <entry>7.1.0</entry>
+       <entry>
+        <function>srand</function> işlevi <function>mt_srand</function>
+        işlevinin <link linkend="migration71.incompatible.rand-srand-aliases">takma adı haline getirildi</link>.
+       </entry>
+      </row>
+      <row>
+       <entry>7.1.0</entry>
+       <entry>
+        <function>mt_rand</function> işlevi, Mersenne Twister algoritmasının
+        sabitlenmiş, doğru sürümünü kullanmak üzere
+        <link linkend="migration71.incompatible.fixes-to-mt_rand-algorithm">güncellendi</link>.
+        Eski davranışa geri dönmek için ikinci bağımsız değişken olarak
+        <constant>MT_RAND_PHP</constant> ile <function>mt_srand</function>
+        kullanılabilir.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>mt_rand</function></member>
+    <member><function>mt_getrandmax</function></member>
+    <member><function>srand</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/random/functions/rand.xml
+++ b/reference/random/functions/rand.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: d6dc2be3c5c70e4a1c3d13f788643ea232747c19 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.rand" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>rand</refname>
+  <refpurpose>Bir rastgele tamsayı üretir</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>rand</methodname>
+   <void/>
+  </methodsynopsis>
+  <methodsynopsis>
+   <type>int</type><methodname>rand</methodname>
+   <methodparam><type>int</type><parameter>asgari</parameter></methodparam>
+   <methodparam><type>int</type><parameter>azami</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Seçimlik <parameter>asgari</parameter> ve <parameter>azami</parameter>
+   bağımsız değişkenleri olmaksızın çağrıldığında <function>rand</function>,
+   0 ile <function>getrandmax</function> arasında bir sözde rastgele tamsayı
+   döndürür. Örneğin, 5 ile 15 (dahil) arasında rastgele bir sayı isteniyorsa
+   <literal>rand(5, 15)</literal> kullanılabilir.
+  </simpara>
+  &caution.cryptographically-insecure;
+  &caution.mt19937-global-state;
+  <note>
+   <simpara>
+    PHP 7.1.0 öncesinde, <function>getrandmax</function> bazı platformlarda
+    (Windows gibi) yalnızca 32767 idi. 32767'den büyük bir aralık
+    gerekiyorsa, <parameter>asgari</parameter> ve <parameter>azami</parameter>
+    bağımsız değişkenleri belirtilerek bundan daha büyük bir aralık
+    oluşturulabilir; ya da bunun yerine <function>mt_rand</function>
+    kullanılabilir.
+   </simpara>
+  </note>
+  <note><simpara>PHP 7.1.0'dan itibaren, <function>rand</function>
+   <function>mt_rand</function> ile aynı rastgele sayı üretecini kullanır.
+   Geriye dönük uyumluluğu korumak amacıyla <function>rand</function>,
+   <function>mt_rand</function> işlevinin aksine
+   <parameter>azami</parameter> değerinin <parameter>asgari</parameter>
+   değerinden küçük olmasına izin verir, &false; döndürmez.</simpara>
+  </note>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>asgari</parameter></term>
+     <listitem>
+      <para>
+       Döndürülecek en küçük değer (öntanımlı: 0)
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>azami</parameter></term>
+     <listitem>
+      <para>
+       Döndürülecek en büyük değer (öntanımlı: <function>getrandmax</function>)
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>asgari</parameter> (veya 0) ile <parameter>azami</parameter>
+   (veya <function>getrandmax</function>, dahil) arasında bir sözde rastgele
+   değer.
+  </para>
+ </refsect1>
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>7.2.0</entry>
+       <entry>
+        <function>rand</function> işlevi, modulo sapma hatası için
+        <link linkend="migration72.incompatible.rand-mt_rand-output">bir hata düzeltmesi aldı</link>.
+        Bu, belirli bir tohumla üretilen dizilerin, 64 bitlik makinelerde
+        PHP 7.1'den farklı olabileceği anlamına gelir.
+       </entry>
+      </row>
+      <row>
+       <entry>7.1.0</entry>
+       <entry>
+        <function>rand</function> işlevi <function>mt_rand</function>
+        işlevinin <link linkend="migration71.incompatible.rand-srand-aliases">takma adı haline getirildi</link>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>rand</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+echo rand(), "\n";
+echo rand(), "\n";
+
+echo rand(5, 15), "\n";
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+7771
+22264
+11
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <warning>
+   <para>
+    <parameter>asgari</parameter> <parameter>azami</parameter> aralığı
+    <function>getrandmax</function> aralığı içinde olmalıdır. Yani
+    abs(<parameter>azami</parameter> - <parameter>asgari</parameter>) &lt;=
+    <function>getrandmax</function>. Aksi takdirde,
+    <function>rand</function> düşük kaliteli rastgele sayılar
+    döndürebilir.
+   </para>
+  </warning>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>srand</function></member>
+    <member><function>getrandmax</function></member>
+    <member><function>mt_rand</function></member>
+    <member><function>random_int</function></member>
+    <member><function>random_bytes</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Add Turkish translations for the procedural `random` functions, none of which had a Turkish version. Covers the six historical PRNG entry points: `rand`, `mt_rand`, `mt_srand`, `lcg_value` (deprecated since PHP 8.4), `getrandmax`, `mt_getrandmax`.

Glossary and corpus respected: `seed → tohum`, `mode → kip`, `min/max → asgari/azami` (consistent with usage elsewhere); the `Random\Randomizer` cross-references in `lcg_value` are left as method names.