### PR TITLE
[Translate] math: abs, ceil, floor, sqrt, pow, fmod

### DIFF
--- a/reference/math/functions/abs.xml
+++ b/reference/math/functions/abs.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 19e8122137a1d42ed60f17fe2c0c2b69b0b2d16b Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.abs" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>abs</refname>
+  <refpurpose>Mutlak değer</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+   <methodsynopsis>
+   <type class="union"><type>int</type><type>float</type></type><methodname>abs</methodname>
+   <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <parameter>sayı</parameter> değerinin mutlak değerini döndürür.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       İşlenecek sayısal değer.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin mutlak değeri.
+   <parameter>sayı</parameter> bağımsız değişkeni <type>float</type>
+   türünde ise dönüş türü de <type>float</type>, aksi halde
+   <type>int</type> olur (<type>float</type> türü genellikle
+   <type>int</type> türünden daha geniş bir değer aralığına sahip
+   olduğundan).
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <parameter>sayı</parameter> artık sayısal dönüşümü destekleyen
+       dahili nesneleri kabul etmemekte.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>abs</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(abs(-4.2));
+var_dump(abs(5));
+var_dump(abs(-5));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+float(4.2)
+int(5)
+int(5)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>gmp_abs</function></member>
+    <member><function>gmp_sign</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/ceil.xml
+++ b/reference/math/functions/ceil.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 761d72245071f89a626903c9bcdc6aaff1252d54 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.ceil" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>ceil</refname>
+  <refpurpose>Kesirleri yukarı yuvarlar</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+   <methodsynopsis>
+   <type>float</type><methodname>ceil</methodname>
+   <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Gerekirse <parameter>sayı</parameter> değerini yukarı yuvarlayarak bir
+   sonraki en büyük tamsayı değerini döndürür.
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       Yuvarlanacak değer.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin bir sonraki en büyük tamsayıya
+   yukarı yuvarlanmış hali. <function>ceil</function> işlevinin dönüş
+   değeri, <type>float</type> türünün değer aralığı genellikle
+   <type>int</type> türünden daha geniş olduğundan yine
+   <type>float</type> türündedir.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <parameter>sayı</parameter> artık sayısal dönüşümü destekleyen
+       dahili nesneleri kabul etmemekte.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>ceil</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+echo ceil(4.3), PHP_EOL;    // 5
+echo ceil(9.999), PHP_EOL;  // 10
+echo ceil(-3.14), PHP_EOL;  // -3
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>floor</function></member>
+    <member><function>round</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/floor.xml
+++ b/reference/math/functions/floor.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 761d72245071f89a626903c9bcdc6aaff1252d54 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.floor" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>floor</refname>
+  <refpurpose>Kesirleri aşağı yuvarlar</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+   <methodsynopsis>
+   <type>float</type><methodname>floor</methodname>
+   <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Gerekirse <parameter>sayı</parameter> değerini aşağı yuvarlayarak bir
+   sonraki en küçük tamsayı değerini (gerçek sayı olarak) döndürür.
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       Yuvarlanacak sayısal değer.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin bir sonraki en küçük tamsayıya
+   yuvarlanmış hali. <function>floor</function> işlevinin dönüş değeri
+   yine <type>float</type> türündedir.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <parameter>sayı</parameter> artık sayısal dönüşümü destekleyen
+       dahili nesneleri kabul etmemekte.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>floor</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+echo floor(4.3), PHP_EOL;   // 4
+echo floor(9.999), PHP_EOL; // 9
+echo floor(-3.14), PHP_EOL; // -4
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>ceil</function></member>
+    <member><function>round</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/fmod.xml
+++ b/reference/math/functions/fmod.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 54a788ca59d95ff2b4189406437345a21b489435 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.fmod" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>fmod</refname>
+  <refpurpose>Bağımsız değişkenlerin bölümünden kalan gerçek sayı kalanını
+  (modulo) döndürür</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>fmod</methodname>
+   <methodparam><type>float</type><parameter>sayı1</parameter></methodparam>
+   <methodparam><type>float</type><parameter>sayı2</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Bölünen (<parameter>sayı1</parameter>) değerinin bölen
+   (<parameter>sayı2</parameter>) değerine bölümünden kalan gerçek sayı
+   kalanını döndürür. Kalan (<varname>r</varname>) şöyle tanımlanır:
+   bir <varname>i</varname> tamsayısı için sayı1 = i * sayı2 + r.
+   <parameter>sayı2</parameter> sıfır değilse, <varname>r</varname>,
+   <parameter>sayı1</parameter> ile aynı işarete sahip olur ve
+   büyüklüğü <parameter>sayı2</parameter> büyüklüğünden küçük olur.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı1</parameter></term>
+     <listitem>
+      <para>
+       Bölünen.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>sayı2</parameter></term>
+     <listitem>
+      <para>
+       Bölen.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı1</parameter>/<parameter>sayı2</parameter> bölümünün
+   gerçek sayı kalanı. İkinci bağımsız değişken 0 ise
+   <constant>NAN</constant> (<type>float</type>).
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>fmod</function> kullanımı</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$x = 5.7;
+$y = 1.3;
+$r = fmod($x, $y);
+// $r 0.5'e eşittir, çünkü 4 * 1.3 + 0.5 = 5.7
+
+var_dump($x, $y, $r);
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><link linkend="language.operators.arithmetic"><literal>/</literal></link> - Gerçek sayı bölmesi</member>
+    <member><link linkend="language.operators.arithmetic"><literal>%</literal></link> - Tamsayı modulosu</member>
+    <member><function>intdiv</function> - Tamsayı bölmesi</member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/pow.xml
+++ b/reference/math/functions/pow.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 761d72245071f89a626903c9bcdc6aaff1252d54 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.pow" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pow</refname>
+  <refpurpose>Üstel ifade</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+   <methodsynopsis>
+   <type class="union"><type>int</type><type>float</type><type>object</type></type><methodname>pow</methodname>
+   <methodparam><type>mixed</type><parameter>sayı</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>üs</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <parameter>sayı</parameter> değerinin <parameter>üs</parameter>'üne
+   yükseltilmiş halini döndürür.
+  </para>
+  <note>
+   <para>
+    Bunun yerine
+    <link linkend="language.operators.arithmetic">**</link> işleci de
+    kullanılabilir.
+   </para>
+  </note>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       Kullanılacak taban.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>üs</parameter></term>
+     <listitem>
+      <para>
+       Üs.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin <parameter>üs</parameter>'üne
+   yükseltilmiş hali. Her iki bağımsız değişken de negatif olmayan
+   tamsayılar ise ve sonuç bir tamsayı olarak ifade edilebiliyorsa, sonuç
+   <type>int</type> türünde döndürülür; aksi takdirde <type>float</type>
+   türünde döndürülür.
+  </para>
+  <para>
+   PHP eklentileri bu işlemin davranışını geçersiz kılarak bir nesne
+   döndürmesini sağlayabilir.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <literal>0</literal> değerini negatif bir <parameter>üs</parameter>
+       ile yükseltmenin kullanımı önerilmemekte.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>pow</function> işlevinden bazı örnekler</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+var_dump(pow(2, 8)); // int(256)
+echo pow(-1, 20), PHP_EOL; // 1
+echo pow(0, 0), PHP_EOL; // 1
+echo pow(10, -1), PHP_EOL; // 0.1
+
+echo pow(-1, 5.5), PHP_EOL; // NAN
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>GMP Eklentisi Nesnesiyle <function>pow</function> Örnekleri</title>
+    <programlisting role="php" annotations="non-interactive">
+<![CDATA[
+<?php
+var_dump(pow(new GMP("3"), new GMP("2"))); // object(GMP)
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    Bu işlev tüm girdiyi, sayıl olmayan değerleri bile bir sayıya
+    dönüştürür; bu da <emphasis>tuhaf</emphasis> sonuçlara yol açabilir.
+   </para>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member>
+     Üs alma işleci
+     <link linkend="language.operators.arithmetic"><literal>**</literal></link>
+    </member>
+    <member><function>fpow</function></member>
+    <member><function>exp</function></member>
+    <member><function>sqrt</function></member>
+    <member><function>bcpow</function></member>
+    <member><function>gmp_pow</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/sqrt.xml
+++ b/reference/math/functions/sqrt.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 761d72245071f89a626903c9bcdc6aaff1252d54 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.sqrt" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>sqrt</refname>
+  <refpurpose>Karekök</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>sqrt</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <parameter>sayı</parameter> değerinin karekökünü döndürür.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       İşlenecek bağımsız değişken.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin karekökü, ya da negatif sayılar
+   için özel <constant>NAN</constant> değeri.
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>sqrt</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// Hassasiyet, precision yönergenize bağlıdır
+echo sqrt(9), PHP_EOL; // 3
+echo sqrt(10), PHP_EOL; // 3.16227766 ...
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pow</function></member>
+    <member><constant>M_SQRTPI</constant> - <code>sqrt(pi)</code></member>
+    <member><constant>M_2_SQRTPI</constant> - <code>2/sqrt(pi)</code></member>
+    <member><constant>M_SQRT2</constant> - <code>sqrt(2)</code></member>
+    <member><constant>M_SQRT3</constant> - <code>sqrt(3)</code></member>
+    <member><constant>M_SQRT1_2</constant> - <code>1/sqrt(2)</code></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Add Turkish translations for six widely-used `math` reference functions: `abs`, `ceil`, `floor`, `sqrt`, `pow`, `fmod`. The `reference/math/functions/` directory had no Turkish files yet, so this opens a chantier that further PRs can extend.

Glossary and corpus respected: `square root → karekök`, `exponential → üstel`, `dividend/divisor → bölünen/bölen`, `num → sayı`. Cross-refs to `gmp_*`, `bcpow`, etc. left as function names.