### PR TITLE
[Sync EN] array: count, usort, array_merge, array_diff, array_combine, array_fill

### DIFF
--- a/reference/array/functions/array-combine.xml
+++ b/reference/array/functions/array-combine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 71e3c74047f04b26aa1be51215d7129e15dc2993 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.array-combine" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_combine</refname>
@@ -111,8 +111,8 @@ print_r($c);
 <![CDATA[
 Array
 (
-    [green]  => avocado
-    [red]    => apple
+    [green] => avocado
+    [red] => apple
     [yellow] => banana
 )
 ]]>

--- a/reference/array/functions/array-combine.xml
+++ b/reference/array/functions/array-combine.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: lacatoire Status: ready -->
+<!-- CREDITS: nilgun -->
 <refentry xml:id="function.array-combine" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_combine</refname>

--- a/reference/array/functions/array-diff.xml
+++ b/reference/array/functions/array-diff.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c84024092aee02b51dd18b909af0f2ccbdd24f98 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.array-diff" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_diff</refname>
@@ -103,14 +103,15 @@ Array
   </para>
 
   <para>
+   İki elemanın eşit olması için sadece ve sadece
+   <literal>(string) $elem1 === (string) $elem2</literal> olmalıdır.
+   Başka bir deyişle, <link linkend="language.types.string.casting">dize
+   gösterimleri</link> aynı olmalıdır.
+  </para>
+
+  <para>
    <example>
     <title>- Eşleşmeyen türler ile <function>array_diff</function></title>
-    <para>
-     İki elemanın eşit olması için sadece ve sadece
-     <literal>(string) $elem1 === (string) $elem2</literal> olmalıdır.
-     Başka bir deyişle, <link linkend="language.types.string.casting">dize
-     gösterimleri</link> aynı olmalıdır.
-    </para>
     <programlisting role="php">
      <![CDATA[
 <?php
@@ -138,14 +139,15 @@ $filter = [new S('b'), new S('c'), new S('d')];
 $result = array_diff($source, $filter);
 
 // $result tek bir S('a') örneği içerir
+var_dump($result);
 ?>
 ]]>
     </programlisting>
-    <para>
-     Başka bir karşılaştırma işlevi kullanmak isterseniz
-     <function>array_udiff</function> işlevine bakın.
-    </para>
    </example>
+  </para>
+  <para>
+   Başka bir karşılaştırma işlevi kullanmak isterseniz
+   <function>array_udiff</function> işlevine bakın.
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-diff.xml
+++ b/reference/array/functions/array-diff.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: lacatoire Status: ready -->
+<!-- CREDITS: nilgun -->
 <refentry xml:id="function.array-diff" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_diff</refname>

--- a/reference/array/functions/array-fill.xml
+++ b/reference/array/functions/array-fill.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: lacatoire Status: ready -->
+<!-- CREDITS: nilgun -->
 <refentry xml:id="function.array-fill" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_fill</refname>

--- a/reference/array/functions/array-fill.xml
+++ b/reference/array/functions/array-fill.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ce882c196dce81bf6bd4d94af4fa4110ddc49ef4 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.array-fill" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_fill</refname>
@@ -147,6 +147,18 @@ print_r($a);
 ?>
 ]]>
     </programlisting>
+    &example.outputs.8;
+    <screen>
+<![CDATA[
+Array
+(
+    [-2] => pear
+    [-1] => pear
+    [0] => pear
+    [1] => pear
+)
+]]>
+    </screen>
     &example.outputs.7;
     <screen>
 <![CDATA[

--- a/reference/array/functions/array-merge.xml
+++ b/reference/array/functions/array-merge.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8859c8b96cd9e80652813f7bcf561432a5e9f934 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.array-merge" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_merge</refname>
@@ -183,12 +183,12 @@ print_r($sonuc);
     </programlisting>
     &example.outputs;
     <screen role="php">
-    <![CDATA[
-    Array
-    (
-        [0] => foo
-        [1] => bar
-    )
+<![CDATA[
+Array
+(
+    [0] => foo
+    [1] => bar
+)
 ]]>
     </screen>
    </example>

--- a/reference/array/functions/array-merge.xml
+++ b/reference/array/functions/array-merge.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: lacatoire Status: ready -->
+<!-- CREDITS: nilgun -->
 <refentry xml:id="function.array-merge" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_merge</refname>

--- a/reference/array/functions/count.xml
+++ b/reference/array/functions/count.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3ef3e56c80f7ae6b6a7291b7eb57dc6250b50801 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.count" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>count</refname>
@@ -111,10 +111,12 @@
 $a[0] = 1;
 $a[1] = 3;
 $a[2] = 5;
-+$b[0]  = 7;
-+$b[5]  = 9;
-+$b[10] = 11;
-+var_dump(count($b));
+var_dump(count($a));
+
+$b[0]  = 7;
+$b[5]  = 9;
+$b[10] = 11;
+var_dump(count($b));
 ?>
 ]]>
     </programlisting>
@@ -130,7 +132,7 @@ int(3)
   <para>
    <example xml:id="count.example.badexample">
     <title>- <function>count</function> geçersiz Countable|array örneği (kötü örnek - yapmaktan sakının)</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $b[0]  = 7;
@@ -145,26 +147,6 @@ var_dump(count(false));
 ]]>
     </programlisting>
     &example.outputs;
-    <screen role="php">
-<![CDATA[
-int(3)
-int(0)
-int(1)
-]]>
-    </screen>
-    &example.outputs.72;
-    <screen role="php">
-<![CDATA[
-int(3)
-
-Warning: count(): Parameter must be an array or an object that implements Countable in … on line 12
-int(0)
-
-Warning: count(): Parameter must be an array or an object that implements Countable in … on line 14
-int(1)
-]]>
-    </screen>
-    &example.outputs.8;
     <screen role="php">
 <![CDATA[
 int(3)

--- a/reference/array/functions/count.xml
+++ b/reference/array/functions/count.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: lacatoire Status: ready -->
+<!-- CREDITS: nilgun -->
 <refentry xml:id="function.count" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>count</refname>

--- a/reference/array/functions/usort.xml
+++ b/reference/array/functions/usort.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2226ad08fd93e3979efbba47c5ae3545eec97d25 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.usort" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>usort</refname>
@@ -152,10 +152,6 @@ foreach ($meyvalar as $anah => $değer) {
 ?>
 ]]>
     </programlisting>
-    <para>
-     Bir çok boyutlu dizi sıralanırken <varname>$a</varname> ve
-    <varname>$b</varname> dizinin ilk indisine gönderimleri içerir.
-    </para>
     &example.outputs;
     <screen>
 <![CDATA[
@@ -164,6 +160,10 @@ $meyvalar[1]: mandalina
 $meyvalar[2]: portakal
 ]]>
     </screen>
+    <para>
+     Bir çok boyutlu dizi sıralanırken <varname>$a</varname> ve
+     <varname>$b</varname> dizinin ilk indisine gönderimleri içerir.
+    </para>
    </example>
   </para>
   <para>
@@ -174,7 +174,7 @@ $meyvalar[2]: portakal
 <![CDATA[
 <?php
 class Deneme {
-    private string $isim;
+    public string $isim;
 
     function __construct($isim)
     {

--- a/reference/array/functions/usort.xml
+++ b/reference/array/functions/usort.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: lacatoire Status: ready -->
+<!-- CREDITS: nilgun -->
 <refentry xml:id="function.usort" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>usort</refname>


### PR DESCRIPTION
Sync six widely-used `array` reference files to EN HEAD `2e60c51` (Enable WASM for book.array, and tweak examples).

`count.xml` also picks up a small drive-by cleanup: the first example had stray `+` diff markers on the `\$b` lines and was missing `var_dump(\$a)`, both pre-existing in the TR copy and now restored to match EN.

Glossary and corpus respected.