### PR TITLE
[Translate] math: sin, cos, tan, asin, acos, atan

### DIFF
--- a/reference/math/functions/acos.xml
+++ b/reference/math/functions/acos.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: abed9056c54488744908309aefc6265f56329dca Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.acos" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>acos</refname>
+  <refpurpose>Ark kosinüs</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>acos</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <parameter>sayı</parameter> değerinin radyan cinsinden ark kosinüsünü
+   döndürür. <function>acos</function>, <function>cos</function> işlevinin
+   ters işlevidir; yani <function>acos</function> tanım kümesindeki her
+   <parameter>sayı</parameter> değeri için
+   <code>$sayı == cos(acos($sayı))</code> doğrudur.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       İşlenecek bağımsız değişken.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin radyan cinsinden ark kosinüsü.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>cos</function></member>
+    <member><function>acosh</function></member>
+    <member><function>asin</function></member>
+    <member><function>atan</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/asin.xml
+++ b/reference/math/functions/asin.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: abed9056c54488744908309aefc6265f56329dca Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.asin" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>asin</refname>
+  <refpurpose>Ark sinüs</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>asin</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <parameter>sayı</parameter> değerinin radyan cinsinden ark sinüsünü
+   döndürür. <function>asin</function>, <function>sin</function> işlevinin
+   ters işlevidir; yani <function>asin</function> tanım kümesindeki her
+   <parameter>sayı</parameter> değeri için
+   <code>$sayı == sin(asin($sayı))</code> doğrudur.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       İşlenecek bağımsız değişken.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin radyan cinsinden ark sinüsü.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>sin</function></member>
+    <member><function>asinh</function></member>
+    <member><function>acos</function></member>
+    <member><function>atan</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/atan.xml
+++ b/reference/math/functions/atan.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: abed9056c54488744908309aefc6265f56329dca Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.atan" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>atan</refname>
+  <refpurpose>Ark tanjant</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>atan</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <parameter>sayı</parameter> değerinin radyan cinsinden ark tanjantını
+   döndürür. <function>atan</function>, <function>tan</function> işlevinin
+   ters işlevidir; yani <function>atan</function> tanım kümesindeki her
+   <parameter>sayı</parameter> değeri için
+   <code>$sayı == tan(atan($sayı))</code> doğrudur.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       İşlenecek bağımsız değişken.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin radyan cinsinden ark tanjantı.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>tan</function></member>
+    <member><function>atanh</function></member>
+    <member><function>asin</function></member>
+    <member><function>acos</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/cos.xml
+++ b/reference/math/functions/cos.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.cos" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>cos</refname>
+  <refpurpose>Kosinüs</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>cos</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>cos</function>, <parameter>sayı</parameter> bağımsız değişkeninin
+   kosinüsünü döndürür. <parameter>sayı</parameter> radyan cinsindendir.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       Radyan cinsinden bir açı.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin kosinüsü.
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>cos</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+echo cos(M_PI); // -1
+
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>acos</function></member>
+    <member><function>sin</function></member>
+    <member><function>tan</function></member>
+    <member><function>deg2rad</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/sin.xml
+++ b/reference/math/functions/sin.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 761d72245071f89a626903c9bcdc6aaff1252d54 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.sin" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>sin</refname>
+  <refpurpose>Sinüs</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>sin</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>sin</function>, <parameter>sayı</parameter> bağımsız değişkeninin
+   sinüsünü döndürür. <parameter>sayı</parameter> radyan cinsindendir.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       Radyan cinsinden bir değer.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin sinüsü.
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>sin</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// Hassasiyet, precision ini yönergesine bağlıdır
+echo sin(deg2rad(60)), PHP_EOL;  //  0.866025403 ...
+echo sin(60), PHP_EOL;           // -0.304810621 ...
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>asin</function></member>
+    <member><function>sinh</function></member>
+    <member><function>cos</function></member>
+    <member><function>tan</function></member>
+    <member><function>deg2rad</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/tan.xml
+++ b/reference/math/functions/tan.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.tan" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>tan</refname>
+  <refpurpose>Tanjant</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>tan</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>tan</function>, <parameter>sayı</parameter> bağımsız değişkeninin
+   tanjantını döndürür. <parameter>sayı</parameter> radyan cinsindendir.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       Radyan cinsinden işlenecek bağımsız değişken.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin tanjantı.
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>tan</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+echo tan(M_PI_4); // 1
+
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>atan</function></member>
+    <member><function>atan2</function></member>
+    <member><function>sin</function></member>
+    <member><function>cos</function></member>
+    <member><function>tanh</function></member>
+    <member><function>deg2rad</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
6 trigonometrik işlevin Türkçe çevirisi. README.md sözlüğüne (sayı, bağımsız değişken, işlev, ters işlev) ve standart matematik terminolojisine (sinüs, kosinüs, tanjant, ark sinüs, ark kosinüs, ark tanjant, radyan) uygun.