### PR TITLE
[Translate] math: sinh, cosh, tanh, asinh, acosh, atanh

### DIFF
--- a/reference/math/functions/acosh.xml
+++ b/reference/math/functions/acosh.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.acosh" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>acosh</refname>
+  <refpurpose>Ters hiperbolik kosinüs</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>acosh</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <parameter>sayı</parameter> değerinin ters hiperbolik kosinüsünü, yani
+   hiperbolik kosinüsü <parameter>sayı</parameter> olan değeri döndürür.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       İşlenecek değer.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin ters hiperbolik kosinüsü.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>cosh</function></member>
+    <member><function>acos</function></member>
+    <member><function>asinh</function></member>
+    <member><function>atanh</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/asinh.xml
+++ b/reference/math/functions/asinh.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.asinh" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>asinh</refname>
+  <refpurpose>Ters hiperbolik sinüs</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>asinh</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <parameter>sayı</parameter> değerinin ters hiperbolik sinüsünü, yani
+   hiperbolik sinüsü <parameter>sayı</parameter> olan değeri döndürür.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       İşlenecek bağımsız değişken.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin ters hiperbolik sinüsü.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>sinh</function></member>
+    <member><function>asin</function></member>
+    <member><function>acosh</function></member>
+    <member><function>atanh</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/atanh.xml
+++ b/reference/math/functions/atanh.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.atanh" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>atanh</refname>
+  <refpurpose>Ters hiperbolik tanjant</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>atanh</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <parameter>sayı</parameter> değerinin ters hiperbolik tanjantını, yani
+   hiperbolik tanjantı <parameter>sayı</parameter> olan değeri döndürür.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       İşlenecek bağımsız değişken.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin ters hiperbolik tanjantı.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>tanh</function></member>
+    <member><function>atan</function></member>
+    <member><function>asinh</function></member>
+    <member><function>acosh</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/cosh.xml
+++ b/reference/math/functions/cosh.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e049a733379781df3440b92fd41c12fe3f8e3b93 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.cosh" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>cosh</refname>
+  <refpurpose>Hiperbolik kosinüs</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>cosh</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <parameter>sayı</parameter> değerinin
+   <literal>(exp($sayı) + exp(-$sayı))/2</literal> olarak tanımlı
+   hiperbolik kosinüsünü döndürür.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       İşlenecek bağımsız değişken.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin hiperbolik kosinüsü.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>cos</function></member>
+    <member><function>acosh</function></member>
+    <member><function>sinh</function></member>
+    <member><function>tanh</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/sinh.xml
+++ b/reference/math/functions/sinh.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e049a733379781df3440b92fd41c12fe3f8e3b93 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.sinh" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>sinh</refname>
+  <refpurpose>Hiperbolik sinüs</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>sinh</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <parameter>sayı</parameter> değerinin
+   <literal>(exp($sayı) - exp(-$sayı))/2</literal> olarak tanımlı
+   hiperbolik sinüsünü döndürür.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       İşlenecek bağımsız değişken.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin hiperbolik sinüsü.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>sin</function></member>
+    <member><function>asinh</function></member>
+    <member><function>cosh</function></member>
+    <member><function>tanh</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/tanh.xml
+++ b/reference/math/functions/tanh.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e049a733379781df3440b92fd41c12fe3f8e3b93 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.tanh" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>tanh</refname>
+  <refpurpose>Hiperbolik tanjant</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>tanh</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <parameter>sayı</parameter> değerinin
+   <literal>sinh($sayı)/cosh($sayı)</literal> olarak tanımlı
+   hiperbolik tanjantını döndürür.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       İşlenecek bağımsız değişken.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin hiperbolik tanjantı.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>tan</function></member>
+    <member><function>atanh</function></member>
+    <member><function>sinh</function></member>
+    <member><function>cosh</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
6 hiperbolik işlevin Türkçe çevirisi. README.md sözlüğüne ve standart matematik terminolojisine (hiperbolik sinüs/kosinüs/tanjant, ters hiperbolik sinüs/kosinüs/tanjant) uygun.