### PR TITLE
[Translate] math: base_convert, bindec, decbin, decoct, dechex, hexdec

### DIFF
--- a/reference/math/functions/base-convert.xml
+++ b/reference/math/functions/base-convert.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 19e8122137a1d42ed60f17fe2c0c2b69b0b2d16b Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.base-convert" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>base_convert</refname>
+  <refpurpose>Bir sayıyı keyfi tabanlar arasında dönüştürür</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+   <methodsynopsis>
+   <type>string</type><methodname>base_convert</methodname>
+   <methodparam><type>string</type><parameter>sayı</parameter></methodparam>
+   <methodparam><type>int</type><parameter>kaynak_taban</parameter></methodparam>
+   <methodparam><type>int</type><parameter>hedef_taban</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <parameter>sayı</parameter> değerinin <parameter>hedef_taban</parameter>
+   tabanındaki gösterimini içeren bir dize döndürür.
+   <parameter>sayı</parameter> değerinin verildiği taban
+   <parameter>kaynak_taban</parameter> ile belirtilir. Hem
+   <parameter>kaynak_taban</parameter> hem de <parameter>hedef_taban</parameter>
+   uçlar dahil 2 ile 36 arasında olmalıdır. Tabanı 10'dan büyük sayılardaki
+   rakamlar a-z harfleriyle gösterilir; a 10, b 11 ve z 35 anlamına gelir.
+   Harflerin büyük ya da küçük olması farketmez, yani
+   <parameter>sayı</parameter> harf büyüklüğüne duyarsız olarak yorumlanır.
+  </para>
+  <warning>
+   <simpara>
+    <function>base_convert</function>, dahili olarak kullanılan <type>float</type>
+    türünün özellikleri nedeniyle büyük sayılarda hassasiyet kaybedebilir.
+    Daha ayrıntılı bilgi ve kısıtlamalar için kılavuzdaki
+    <link linkend="language.types.float">Gerçek sayılar</link> bölümüne
+    bakınız.
+   </simpara>
+  </warning>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       Dönüştürülecek sayı. <parameter>sayı</parameter> içindeki geçersiz
+       karakterler sessizce yok sayılır.
+       PHP 7.4.0'dan itibaren geçersiz karakter aktarmak artık önerilmemektedir.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>kaynak_taban</parameter></term>
+     <listitem>
+      <para>
+       <parameter>sayı</parameter> değerinin bulunduğu taban.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>hedef_taban</parameter></term>
+     <listitem>
+      <para>
+       <parameter>sayı</parameter> değerinin dönüştürüleceği taban.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin <parameter>hedef_taban</parameter>
+   tabanına dönüştürülmüş hali.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>7.4.0</entry>
+      <entry>
+       Geçersiz karakter aktarmak artık bir önerilmiyor bildirimi üretir.
+       Sonuç, geçersiz karakterler yokmuş gibi hesaplanmaya devam eder.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>base_convert</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$onaltilik = 'a37334';
+echo base_convert($onaltilik, 16, 2);
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+101000110111001100110100
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>intval</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/bindec.xml
+++ b/reference/math/functions/bindec.xml
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.bindec" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>bindec</refname>
+  <refpurpose>İkilikten onluğa</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+   <methodsynopsis>
+    <type class="union"><type>int</type><type>float</type></type><methodname>bindec</methodname>
+    <methodparam><type>string</type><parameter>ikilik_dize</parameter></methodparam>
+   </methodsynopsis>
+  <para>
+   <parameter>ikilik_dize</parameter> bağımsız değişkeniyle temsil edilen
+   ikilik sayının onluk eşdeğerini döndürür.
+  </para>
+  <para>
+   <function>bindec</function>, bir ikilik sayıyı <type>int</type>'e veya,
+   boyut nedeniyle gerekirse <type>float</type>'a dönüştürür.
+  </para>
+  <para>
+   <function>bindec</function>, tüm <parameter>ikilik_dize</parameter>
+   değerlerini işaretsiz tamsayı olarak yorumlar. Bunun nedeni,
+   <function>bindec</function>'in en anlamlı biti işaret biti olarak değil,
+   bir büyüklük basamağı olarak görmesidir.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>ikilik_dize</parameter></term>
+     <listitem>
+      <para>
+       Dönüştürülecek ikilik dize.
+       <parameter>ikilik_dize</parameter> içindeki geçersiz karakterler
+       sessizce yok sayılır.
+       PHP 7.4.0'dan itibaren geçersiz karakter aktarmak artık
+       önerilmemektedir.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+  <warning>
+   <para>
+    Bağımsız değişken bir dize olmalıdır. Başka veri türleri kullanmak
+    beklenmedik sonuçlara yol açacaktır.
+   </para>
+  </warning>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>ikilik_dize</parameter> değerinin onluk karşılığı.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>7.4.0</entry>
+      <entry>
+       Geçersiz karakter aktarmak artık bir önerilmiyor bildirimi üretir.
+       Sonuç, geçersiz karakterler yokmuş gibi hesaplanmaya devam eder.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>bindec</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+echo bindec('110011') . "\n";
+echo bindec('000110011') . "\n";
+
+echo bindec('111');
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+51
+51
+7
+]]>
+    </screen>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title><function>bindec</function> girdiyi işaretsiz tamsayı olarak yorumlar</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+/*
+ * Bu örneğin asıl dersi, PHP kodunun kendisinde değil,
+ * çıktısındadır.
+ */
+
+$buyukluk_alt = pow(2, (PHP_INT_SIZE * 8) - 2);
+p($buyukluk_alt - 1);
+p($buyukluk_alt, 'Taşmayı görüyor musunuz? Bir sonraki turda da izleyin...');
+
+p(PHP_INT_MAX, 'PHP_INT_MAX');
+p(~PHP_INT_MAX, 'PHP_INT_MAX değerinden bir fazlası olarak yorumlanır');
+
+if (PHP_INT_SIZE == 4) {
+    $not = 'en büyük işaretsiz tamsayı olarak yorumlanır';
+} else {
+    $not = 'en büyük işaretsiz tamsayı olarak yorumlanır
+              (18446744073709551615) ancak float hassasiyeti tarafından çarpıtılır';
+}
+p(-1, $not);
+
+
+function p($girdi, $not = '') {
+    echo "girdi:        $girdi\n";
+
+    $bicim = '%0' . (PHP_INT_SIZE * 8) . 'b';
+    $ikilik = sprintf($bicim, $girdi);
+    echo "ikilik:       $ikilik\n";
+
+    ini_set('precision', 20);  // 64 bit makinelerde okunabilirlik için.
+    $onluk = bindec($ikilik);
+    echo 'bindec():     ' . $onluk . "\n";
+
+    if ($not) {
+        echo "NOT:          $not\n";
+    }
+
+    echo "\n";
+}
+?>
+]]>
+    </programlisting>
+    &example.outputs.32bit;
+    <screen>
+<![CDATA[
+girdi:        1073741823
+ikilik:       00111111111111111111111111111111
+bindec():     1073741823
+
+girdi:        1073741824
+ikilik:       01000000000000000000000000000000
+bindec():     1073741824
+NOT:          Taşmayı görüyor musunuz? Bir sonraki turda da izleyin...
+
+girdi:        2147483647
+ikilik:       01111111111111111111111111111111
+bindec():     2147483647
+NOT:          PHP_INT_MAX
+
+girdi:        -2147483648
+ikilik:       10000000000000000000000000000000
+bindec():     2147483648
+NOT:          PHP_INT_MAX değerinden bir fazlası olarak yorumlanır
+
+girdi:        -1
+ikilik:       11111111111111111111111111111111
+bindec():     4294967295
+NOT:          en büyük işaretsiz tamsayı olarak yorumlanır
+]]>
+    </screen>
+    &example.outputs.64bit;
+    <screen>
+<![CDATA[
+girdi:        4611686018427387903
+ikilik:       0011111111111111111111111111111111111111111111111111111111111111
+bindec():     4611686018427387903
+
+girdi:        4611686018427387904
+ikilik:       0100000000000000000000000000000000000000000000000000000000000000
+bindec():     4611686018427387904
+NOT:          Taşmayı görüyor musunuz? Bir sonraki turda da izleyin...
+
+girdi:        9223372036854775807
+ikilik:       0111111111111111111111111111111111111111111111111111111111111111
+bindec():     9223372036854775807
+NOT:          PHP_INT_MAX
+
+girdi:        -9223372036854775808
+ikilik:       1000000000000000000000000000000000000000000000000000000000000000
+bindec():     9223372036854775808
+NOT:          PHP_INT_MAX değerinden bir fazlası olarak yorumlanır
+
+girdi:        -1
+ikilik:       1111111111111111111111111111111111111111111111111111111111111111
+bindec():     18446744073709551616
+NOT:          en büyük işaretsiz tamsayı olarak yorumlanır
+              (18446744073709551615) ancak float hassasiyeti tarafından çarpıtılır
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    Bu işlev, platformun <type>int</type> türüne sığamayacak kadar büyük
+    sayıları dönüştürebilir; bu durumda daha büyük değerler
+    <type>float</type> olarak döndürülür.
+   </para>
+  </note>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>decbin</function></member>
+    <member><function>octdec</function></member>
+    <member><function>hexdec</function></member>
+    <member><function>base_convert</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/decbin.xml
+++ b/reference/math/functions/decbin.xml
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.decbin" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>decbin</refname>
+  <refpurpose>Onluktan ikiliğe</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>decbin</methodname>
+   <methodparam><type>int</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Verilen <parameter>sayı</parameter> bağımsız değişkeninin ikilik
+   gösterimini içeren bir dize döndürür.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       Dönüştürülecek onluk değer.
+      </para>
+
+      <table>
+       <title>32 bitlik makinelerde girdi aralığı</title>
+       <tgroup cols="3">
+        <colspec colname="c1"/>
+        <colspec colname="c2"/>
+        <colspec colname="c3"/>
+        <thead>
+         <row>
+          <entry>pozitif <parameter>sayı</parameter></entry>
+          <entry>negatif <parameter>sayı</parameter></entry>
+          <entry>dönüş değeri</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>0</entry>
+          <entry/>
+          <entry>0</entry>
+         </row>
+         <row>
+          <entry>1</entry>
+          <entry/>
+          <entry>1</entry>
+         </row>
+         <row>
+          <entry>2</entry>
+          <entry/>
+          <entry>10</entry>
+         </row>
+         <row>
+          <entry namest="c1" nameend="c3">... olağan ilerleme ...</entry>
+         </row>
+         <row>
+          <entry>2147483646</entry>
+          <entry/>
+          <entry>1111111111111111111111111111110</entry>
+         </row>
+         <row>
+          <entry>2147483647 (en büyük işaretli tamsayı)</entry>
+          <entry/>
+          <entry>1111111111111111111111111111111 (31 tane 1)</entry>
+         </row>
+         <row>
+          <entry>2147483648</entry>
+          <entry>-2147483648</entry>
+          <entry>10000000000000000000000000000000</entry>
+         </row>
+         <row>
+          <entry namest="c1" nameend="c3">... olağan ilerleme ...</entry>
+         </row>
+         <row>
+          <entry>4294967294</entry>
+          <entry>-2</entry>
+          <entry>11111111111111111111111111111110</entry>
+         </row>
+         <row>
+          <entry>4294967295 (en büyük işaretsiz tamsayı)</entry>
+          <entry>-1</entry>
+          <entry>11111111111111111111111111111111 (32 tane 1)</entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+
+      <table>
+       <title>64 bitlik makinelerde girdi aralığı</title>
+       <tgroup cols="3">
+        <colspec colname="c1"/>
+        <colspec colname="c2"/>
+        <colspec colname="c3"/>
+        <thead>
+         <row>
+          <entry>pozitif <parameter>sayı</parameter></entry>
+          <entry>negatif <parameter>sayı</parameter></entry>
+          <entry>dönüş değeri</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>0</entry>
+          <entry/>
+          <entry>0</entry>
+         </row>
+         <row>
+          <entry>1</entry>
+          <entry/>
+          <entry>1</entry>
+         </row>
+         <row>
+          <entry>2</entry>
+          <entry/>
+          <entry>10</entry>
+         </row>
+         <row>
+          <entry namest="c1" nameend="c3">... olağan ilerleme ...</entry>
+         </row>
+         <row>
+          <entry>9223372036854775806</entry>
+          <entry/>
+          <entry>111111111111111111111111111111111111111111111111111111111111110</entry>
+         </row>
+         <row>
+          <entry>9223372036854775807 (en büyük işaretli tamsayı)</entry>
+          <entry/>
+          <entry>111111111111111111111111111111111111111111111111111111111111111 (63 tane 1)</entry>
+         </row>
+         <row>
+          <entry/>
+          <entry>-9223372036854775808</entry>
+          <entry>1000000000000000000000000000000000000000000000000000000000000000</entry>
+         </row>
+         <row>
+          <entry namest="c1" nameend="c3">... olağan ilerleme ...</entry>
+         </row>
+         <row>
+          <entry/>
+          <entry>-2</entry>
+          <entry>1111111111111111111111111111111111111111111111111111111111111110</entry>
+         </row>
+         <row>
+          <entry/>
+          <entry>-1</entry>
+          <entry>1111111111111111111111111111111111111111111111111111111111111111 (64 tane 1)</entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin ikilik dize gösterimi.
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>decbin</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+echo decbin(12) . "\n";
+echo decbin(26);
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+1100
+11010
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>bindec</function></member>
+    <member><function>decoct</function></member>
+    <member><function>dechex</function></member>
+    <member><function>base_convert</function></member>
+    <member>
+     <function>printf</function>, biçim olarak <literal>%b</literal>,
+     <literal>%032b</literal> veya <literal>%064b</literal> ile
+    </member>
+    <member>
+     <function>sprintf</function>, biçim olarak <literal>%b</literal>,
+     <literal>%032b</literal> veya <literal>%064b</literal> ile
+    </member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/dechex.xml
+++ b/reference/math/functions/dechex.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.dechex" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>dechex</refname>
+  <refpurpose>Onluktan onaltılığa</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>dechex</methodname>
+   <methodparam><type>int</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Verilen işaretsiz <parameter>sayı</parameter> bağımsız değişkeninin
+   onaltılık gösterimini içeren bir dize döndürür.
+  </para>
+  <para>
+   Dönüştürülebilecek en büyük sayı
+   <constant>PHP_INT_MAX</constant><literal> * 2 + 1</literal>'dir (veya
+   <literal>-1</literal>): 32 bitlik platformlarda bu, onluk tabanda
+   <literal>4294967295</literal>'tir ve <function>dechex</function> bunun için
+   <literal>ffffffff</literal> döndürür.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       Dönüştürülecek onluk değer.
+      </para>
+      <para>
+       PHP'nin <type>int</type> türü işaretli olduğundan, ancak
+       <function>dechex</function> işaretsiz tamsayılarla çalıştığından,
+       negatif tamsayılar işaretsizmiş gibi ele alınır.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin onaltılık dize gösterimi.
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>dechex</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+echo dechex(10) . "\n";
+echo dechex(47);
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+a
+2f
+]]>
+    </screen>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Büyük tamsayılarla <function>dechex</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// Aşağıdaki çıktı 32 bitlik bir platform varsayar.
+// Tüm değerler için çıktının aynı olduğuna dikkat edin.
+echo dechex(-1)."\n";
+echo dechex(PHP_INT_MAX * 2 + 1)."\n";
+echo dechex(pow(2, 32) - 1)."\n";
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+ffffffff
+ffffffff
+ffffffff
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>hexdec</function></member>
+    <member><function>decbin</function></member>
+    <member><function>decoct</function></member>
+    <member><function>base_convert</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/decoct.xml
+++ b/reference/math/functions/decoct.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.decoct" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>decoct</refname>
+  <refpurpose>Onluktan sekizliğe</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>decoct</methodname>
+   <methodparam><type>int</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Verilen <parameter>sayı</parameter> bağımsız değişkeninin sekizlik
+   gösterimini içeren bir dize döndürür. Dönüştürülebilecek en büyük sayı,
+   kullanılan platforma bağlıdır. 32 bitlik platformlarda bu sayı genellikle
+   onluk tabanda <literal>4294967295</literal> olup <literal>37777777777</literal>
+   sonucunu üretir. 64 bitlik platformlarda ise genellikle onluk tabanda
+   <literal>9223372036854775807</literal> olup
+   <literal>777777777777777777777</literal> sonucunu üretir.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       Dönüştürülecek onluk değer.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin sekizlik dize gösterimi.
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>decoct</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+echo decoct(15) . "\n";
+echo decoct(264);
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+17
+410
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>octdec</function></member>
+    <member><function>decbin</function></member>
+    <member><function>dechex</function></member>
+    <member><function>base_convert</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/hexdec.xml
+++ b/reference/math/functions/hexdec.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 761d72245071f89a626903c9bcdc6aaff1252d54 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.hexdec" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>hexdec</refname>
+  <refpurpose>Onaltılıktan onluğa</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+   <methodsynopsis>
+    <type class="union"><type>int</type><type>float</type></type><methodname>hexdec</methodname>
+    <methodparam><type>string</type><parameter>onaltılık_dize</parameter></methodparam>
+   </methodsynopsis>
+  <para>
+   <parameter>onaltılık_dize</parameter> bağımsız değişkeninin temsil ettiği
+   onaltılık sayının onluk eşdeğerini döndürür.
+   <function>hexdec</function>, bir onaltılık dizeyi onluk sayıya dönüştürür.
+  </para>
+  <para>
+   <function>hexdec</function> karşılaştığı onaltılık olmayan tüm karakterleri
+   yok sayar.
+   PHP 7.4.0'dan itibaren geçersiz karakter aktarmak artık önerilmemektedir.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>onaltılık_dize</parameter></term>
+     <listitem>
+      <para>
+       Dönüştürülecek onaltılık dize.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>onaltılık_dize</parameter> değerinin onluk gösterimi.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>7.4.0</entry>
+      <entry>
+       Geçersiz karakter aktarmak artık bir önerilmiyor bildirimi üretir.
+       Sonuç, geçersiz karakterler yokmuş gibi hesaplanmaya devam eder.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>hexdec</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(hexdec("ee")); // "int(238)" basar
+var_dump(hexdec("a0")); // "int(160)" basar
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Geçersiz karakterlerle <function>hexdec</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(hexdec("See"));  // "int(238)" basar
+var_dump(hexdec("that")); // "int(10)" basar
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    Bu işlev, platformun <type>int</type> türüne sığamayacak kadar büyük
+    sayıları dönüştürebilir; bu durumda daha büyük değerler
+    <type>float</type> olarak döndürülür.
+   </para>
+  </note>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>dechex</function></member>
+    <member><function>bindec</function></member>
+    <member><function>octdec</function></member>
+    <member><function>base_convert</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
6 taban dönüşüm işlevinin Türkçe çevirisi. README.md sözlüğüne (sayı, bağımsız değişken, taban, dize, gerçek sayı) ve mevcut korpustaki terminolojiye (onluk, onaltılık, sekizlik, ikilik, rakam) uygun.