### PR TITLE
[Sync EN] datetime: date_sun_info, date_sunrise, date_sunset, gmstrftime, idate, strptime

### DIFF
--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 03b6583a4ade7a2b68b57fe958d2d9022b15a873 Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: behzat Status: ready -->
 <refentry xml:id="function.date-sun-info" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>date_sun_info</refname>
@@ -180,7 +180,6 @@ $sun_info = date_sun_info(strtotime("2008-12-12"), 36.55, 32.03);
 foreach ($sun_info as $key => $val) {
     echo "$key: " . date("H:i:s", $val) . "\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -219,7 +218,6 @@ foreach ($si as $key => $value) {
         ": {$key}",
         "\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -247,7 +245,6 @@ never: sunset
 <?php
 $si = date_sun_info(strtotime("2022-06-26"), 69.68, 18.94);
 print_r($si);
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -281,7 +278,6 @@ $diff = $si['sunset'] - $si['sunrise'];
 echo "Length of day: ",
     floor($diff / 3600), "h ",
     floor(($diff % 3600) / 60), "s\n";
-?>
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/datetime/functions/date-sunrise.xml
+++ b/reference/datetime/functions/date-sunrise.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 5c951013ca04161992efed8b86fb40f55669958e Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: behzat Status: ready -->
 <refentry xml:id="function.date-sunrise" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>date_sunrise</refname>
@@ -20,6 +20,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <type class="union"><type>string</type><type>int</type><type>float</type><type>false</type></type><methodname>date_sunrise</methodname>
    <methodparam choice="opt"><type>int</type><parameter>dönüş_biçimi</parameter><initializer><constant>SUNFUNCS_RET_STRING</constant></initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>float</type><type>null</type></type><parameter>enlem</parameter><initializer>&null;</initializer></methodparam>
@@ -223,13 +224,13 @@ saat farkı: +2 GMT
 */
 
 echo date("D M d Y"). ', şafak: ' .date_sunrise(time(), SUNFUNCS_RET_STRING, 41.01, 28.58, 90, 2);
-
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
     <screen>
 <![CDATA[
+Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in script on line 10
+Deprecated: Function date_sunrise() is deprecated since 8.1, use date_sun_info() instead in script on line 10
 Fri Dec 12 2008, şafak: 07:25
 ]]>
     </screen>
@@ -241,12 +242,13 @@ Fri Dec 12 2008, şafak: 07:25
 <?php
 $solstice = strtotime('2017-12-21');
 var_dump(date_sunrise($solstice, SUNFUNCS_RET_STRING, 69.245833, -53.537222));
-?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
+Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in script on line 3
+Deprecated: Function date_sunrise() is deprecated since 8.1, use date_sun_info() instead in script on line 3
 bool(false)
 ]]>
     </screen>

--- a/reference/datetime/functions/date-sunset.xml
+++ b/reference/datetime/functions/date-sunset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5c951013ca04161992efed8b86fb40f55669958e Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: behzat Status: ready -->
 <refentry xml:id="function.date-sunset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>date_sunset</refname>
@@ -21,6 +21,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <type class="union"><type>string</type><type>int</type><type>float</type><type>false</type></type><methodname>date_sunset</methodname>
    <methodparam choice="opt"><type>int</type><parameter>dönüş_biçimi</parameter><initializer><constant>SUNFUNCS_RET_STRING</constant></initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>float</type><type>null</type></type><parameter>enlem</parameter><initializer>&null;</initializer></methodparam>
@@ -224,13 +225,13 @@ saat farkı: +2 GMT
 */
 
 echo date("D M d Y"). ', günbatımı: ' .date_sunset(time(), SUNFUNCS_RET_STRING, 41.01, 28.58, 90, 2);
-
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
     <screen>
 <![CDATA[
+Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in script on line 10
+Deprecated: Function date_sunset() is deprecated since 8.1, use date_sun_info() instead in script on line 10
 Thu Dec 11 2008, günbatımı: 16:33
 ]]>
     </screen>
@@ -242,12 +243,13 @@ Thu Dec 11 2008, günbatımı: 16:33
 <?php
 $solstice = strtotime('2017-12-21');
 var_dump(date_sunset($solstice, SUNFUNCS_RET_STRING, 69.245833, -53.537222));
-?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
+Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in script on line 3
+Deprecated: Function date_sunset() is deprecated since 8.1, use date_sun_info() instead in script on line 3
 bool(false)
 ]]>
     </screen>

--- a/reference/datetime/functions/gmstrftime.xml
+++ b/reference/datetime/functions/gmstrftime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5c951013ca04161992efed8b86fb40f55669958e Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: behzat Status: ready -->
 <refentry xml:id="function.gmstrftime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmstrftime</refname>
@@ -18,6 +18,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <type class="union"><type>string</type><type>false</type></type><methodname>gmstrftime</methodname>
    <methodparam><type>string</type><parameter>biçem</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>zaman_damgası</parameter><initializer>&null;</initializer></methodparam>
@@ -101,7 +102,6 @@
 setlocale(LC_TIME, 'en_US');
 echo strftime("%b %d %Y %H:%M:%S", mktime(20, 0, 0, 12, 31, 98)) . "\n";
 echo gmstrftime("%b %d %Y %H:%M:%S", mktime(20, 0, 0, 12, 31, 98)) . "\n";
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/datetime/functions/idate.xml
+++ b/reference/datetime/functions/idate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5c951013ca04161992efed8b86fb40f55669958e Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: behzat Status: ready -->
 <refentry xml:id="function.idate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>idate</refname>
@@ -201,14 +201,23 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$timestamp = strtotime('1st January 2004'); //1072915200
+$timestamp = strtotime('1st January 2004'); // 1072915200
 
 // Yılı iki haneli basması gerekirse de
 // başında "0" olmadan sadece "4" basar
+echo idate('y', $timestamp) . "\n";
+
+$timestamp = strtotime('1st January 2024'); // 1704067200
 echo idate('y', $timestamp);
-?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+4
+24
+]]>
+    </screen>
    </example>
   </para>
  </refsect1>

--- a/reference/datetime/functions/strptime.xml
+++ b/reference/datetime/functions/strptime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 5c951013ca04161992efed8b86fb40f55669958e Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: behzat Status: ready -->
 <refentry xml:id="function.strptime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>strptime</refname>
@@ -16,6 +16,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <type class="union"><type>array</type><type>false</type></type><methodname>strptime</methodname>
    <methodparam><type>string</type><parameter>zaman_damgası</parameter></methodparam>
    <methodparam><type>string</type><parameter>biçim</parameter></methodparam>
@@ -165,7 +166,6 @@ $strf = strftime($biçim);
 echo "$strf\n";
 
 print_r(strptime($strf, $biçim));
-?>
 ]]>
    </programlisting>
    &example.outputs.similar;


### PR DESCRIPTION
6 datetime işlevini son EN revizyonuna (3a8c3e77) günceller. Başlıca değişiklikler: önerilmeyen işlevler (date_sunrise, date_sunset, gmstrftime, strptime) için yöntem özetlerine #[\Deprecated] niteleyicisi eklendi ve örnek çıktılarına önerilmeme bildirimleri yansıtıldı; idate örneğine ikinci tarih ve çıktı bloğu eklendi.