### PR TITLE
[Translate] math: exp, expm1, log, log10, log1p, pi

### DIFF
--- a/reference/math/functions/exp.xml
+++ b/reference/math/functions/exp.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 761d72245071f89a626903c9bcdc6aaff1252d54 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.exp" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>exp</refname>
+  <refpurpose><constant>e</constant> sayısının üssünü hesaplar</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>exp</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <constant>e</constant> sayısının <parameter>sayı</parameter> üssünü
+   döndürür.
+  </para>
+  <note>
+   <para>
+    '<constant>e</constant>', doğal logaritma sisteminin tabanı olup
+    yaklaşık değeri 2.718282'dir.
+   </para>
+  </note>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       İşlenecek bağımsız değişken.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <constant>e</constant> sayısının <parameter>sayı</parameter> üssü.
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>exp</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+echo exp(12), PHP_EOL;
+echo exp(5.7);
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+162754.791419
+298.86740096706
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>log</function></member>
+    <member><function>pow</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/expm1.xml
+++ b/reference/math/functions/expm1.xml
@@ -15,16 +15,11 @@
    <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
   </methodsynopsis>
   <para>
-    <function>expm1</function>,
-    <parameter>sayı</parameter> değeri sıfıra yakın olduğu durumda,
-    <code>exp($<parameter>sayı</parameter>) - 1</code> ifadesinin neredeyse eşit
-    iki sayının çıkarılması nedeniyle hatalı sonuç verebileceği durumda bile,
-    sonucu doğru kalacak biçimde hesaplayıp döndürür.
-   <code>exp($<parameter>sayı</parameter>) - 1</code> ifadesinin eşdeğerini,
-   <parameter>sayı</parameter> değeri sıfıra yakın olduğunda bile doğru
-   kalacak biçimde hesaplayıp döndürür. Bu durumda,
-   <code>exp($<parameter>sayı</parameter>) - 1</code> ifadesi neredeyse eşit
-   iki sayının çıkarılması nedeniyle hatalı sonuç verirdi.
+   <function>expm1</function>,
+   <parameter>sayı</parameter> değeri sıfıra yakın olduğu durumda,
+   <code>exp($<parameter>sayı</parameter>) - 1</code> ifadesinin neredeyse eşit
+   iki sayının çıkarılması nedeniyle hatalı sonuç verebileceği durumda bile,
+   sonucu doğru kalacak biçimde hesaplayıp döndürür.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/math/functions/expm1.xml
+++ b/reference/math/functions/expm1.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 6abd858a41bad835a3ef5b0d02e3896733e72415 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.expm1">
+ <refnamediv>
+  <refname>expm1</refname>
+  <refpurpose>
+   <code>exp($sayı) - 1</code> ifadesinin sonucunu, sayının değeri sıfıra
+   yakın olduğunda bile doğru kalacak biçimde döndürür
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>expm1</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>expm1</function>,
+   <code>exp($<parameter>sayı</parameter>) - 1</code> ifadesinin eşdeğerini,
+   <parameter>sayı</parameter> değeri sıfıra yakın olduğunda bile doğru
+   kalacak biçimde hesaplayıp döndürür. Bu durumda,
+   <code>exp($<parameter>sayı</parameter>) - 1</code> ifadesi neredeyse eşit
+   iki sayının çıkarılması nedeniyle hatalı sonuç verirdi.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       İşlenecek bağımsız değişken.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <literal>e</literal> sayısının <parameter>sayı</parameter> üssünden bir
+   eksiği.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>log1p</function></member>
+    <member><function>exp</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/expm1.xml
+++ b/reference/math/functions/expm1.xml
@@ -15,7 +15,11 @@
    <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>expm1</function>,
+    <function>expm1</function>,
+    <parameter>sayı</parameter> değeri sıfıra yakın olduğu durumda,
+    <code>exp($<parameter>sayı</parameter>) - 1</code> ifadesinin neredeyse eşit
+    iki sayının çıkarılması nedeniyle hatalı sonuç verebileceği durumda bile,
+    sonucu doğru kalacak biçimde hesaplayıp döndürür.
    <code>exp($<parameter>sayı</parameter>) - 1</code> ifadesinin eşdeğerini,
    <parameter>sayı</parameter> değeri sıfıra yakın olduğunda bile doğru
    kalacak biçimde hesaplayıp döndürür. Bu durumda,

--- a/reference/math/functions/log.xml
+++ b/reference/math/functions/log.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 26ce97891946b6ce1d7e79c171802a447e1eea34 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.log" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>log</refname>
+  <refpurpose>Doğal logaritma</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>log</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+   <methodparam choice="opt"><type>float</type><parameter>taban</parameter><initializer><constant>M_E</constant></initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   İsteğe bağlı <parameter>taban</parameter> bağımsız değişkeni belirtilmişse
+   <function>log</function>, <parameter>sayı</parameter> değerinin
+   <parameter>taban</parameter> tabanındaki logaritmasını
+   (log<subscript>taban</subscript> <parameter>sayı</parameter>) döndürür;
+   aksi takdirde <function>log</function>, <parameter>sayı</parameter>
+   değerinin doğal logaritmasını döndürür.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       Logaritması hesaplanacak değer.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>taban</parameter></term>
+     <listitem>
+      <para>
+       Kullanılacak isteğe bağlı logaritma tabanı
+       (öntanımlı değer 'e' olup doğal logaritmayı verir).
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>taban</parameter> belirtilmişse <parameter>sayı</parameter>
+   değerinin <parameter>taban</parameter> tabanındaki logaritması, aksi
+   takdirde doğal logaritması.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>log10</function></member>
+    <member><function>exp</function></member>
+    <member><function>pow</function></member>
+    <member><function>error_log</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/log10.xml
+++ b/reference/math/functions/log10.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.log10">
+ <refnamediv>
+  <refname>log10</refname>
+  <refpurpose>10 tabanında logaritma</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>log10</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <parameter>sayı</parameter> değerinin 10 tabanındaki logaritmasını
+   döndürür.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       İşlenecek bağımsız değişken.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <parameter>sayı</parameter> değerinin 10 tabanındaki logaritması.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>log</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/log1p.xml
+++ b/reference/math/functions/log1p.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.log1p">
+ <refnamediv>
+  <refname>log1p</refname>
+  <refpurpose>
+   log(1 + sayı) ifadesinin sonucunu, sayının değeri sıfıra yakın olduğunda
+   bile doğru kalacak biçimde döndürür
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>log1p</methodname>
+   <methodparam><type>float</type><parameter>sayı</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>log1p</function>, log(1 + <parameter>sayı</parameter>)
+   ifadesinin sonucunu, <parameter>sayı</parameter> değeri sıfıra yakın
+   olduğunda bile doğru kalacak biçimde hesaplayıp döndürür. Bu durumda
+   <function>log</function> işlevi hassasiyet yetersizliği nedeniyle yalnızca
+   log(1) değerini döndürebilir.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sayı</parameter></term>
+     <listitem>
+      <para>
+       İşlenecek bağımsız değişken.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   log(1 + <parameter>sayı</parameter>).
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>expm1</function></member>
+    <member><function>log</function></member>
+    <member><function>log10</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/math/functions/pi.xml
+++ b/reference/math/functions/pi.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 761d72245071f89a626903c9bcdc6aaff1252d54 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.pi" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pi</refname>
+  <refpurpose>Pi sayısının değerini döndürür</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+   <methodsynopsis>
+    <type>float</type><methodname>pi</methodname>
+    <void/>
+   </methodsynopsis>
+  <simpara>
+   Pi sayısının yaklaşık değerini döndürür.
+   Ayrıca, <function>pi</function> işleviyle özdeş sonucu veren
+   <constant>M_PI</constant> sabiti de kullanılabilir.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Pi sayısının <type>float</type> türünde değeri.
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>pi</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+echo pi(), PHP_EOL; // 3.1415926535898
+echo M_PI, PHP_EOL; // 3.1415926535898
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
6 üstel ve logaritma işlevinin Türkçe çevirisi. README.md sözlüğüne (sayı, bağımsız değişken, işlev, taban) ve mevcut korpustaki terminolojiye (logaritma, üs, doğal logaritma, yaklaşık) uygun.