### PR TITLE
[Sync EN] mbstring: mb_strtolower, mb_convert_case, mb_convert_encoding, mb_convert_kana

### DIFF
--- a/reference/mbstring/functions/mb-convert-case.xml
+++ b/reference/mbstring/functions/mb-convert-case.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4afab59db15ea4b7c5dc2132d85932b4859bcf2 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: d6f54016d62904cfd8200604aadd5e3f0d9bad97 Maintainer: nilgun Status: ready -->
 <refentry xml:id="function.mb-convert-case" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_convert_case</refname>
@@ -78,6 +78,16 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.3.0</entry>
+       <entry>
+        Yunanca sigma harfi için koşullu büyük-küçük harf kuralları gerçeklendi;
+        bu kurallar yalnızca <constant>MB_CASE_LOWER</constant>
+        ve <constant>MB_CASE_TITLE</constant> kiplerine uygulanır,
+        <constant>MB_CASE_LOWER_SIMPLE</constant> ve
+        <constant>MB_CASE_TITLE_SIMPLE</constant> kiplerine uygulanmaz.
+       </entry>
+      </row>
+      <row>
        <entry>7.3.0</entry>
        <entry><parameter>kip</parameter> artık
         <constant>MB_CASE_FOLD</constant>,
@@ -102,11 +112,11 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$str = "Pınar'ın çok sevdiği küçük bir kuzusu var.\n";
+$str = "Pınar'ın çok sevdiği küçük bir kuzusu var.";
 $str = mb_convert_case($str, MB_CASE_UPPER, "UTF-8");
-echo $str; // PINAR'IN ÇOK SEVDIĞI KÜÇÜK BIR KUZUSU VAR.
+echo $str, PHP_EOL;
 $str = mb_convert_case($str, MB_CASE_TITLE, "UTF-8");
-echo $str; // Pinar'in Çok Sevdiği Küçük Bir Kuzusu Var.
+echo $str, PHP_EOL;
 ?>
 ]]>
     </programlisting>
@@ -118,11 +128,11 @@ echo $str; // Pinar'in Çok Sevdiği Küçük Bir Kuzusu Var.
     <programlisting role="php">
 <![CDATA[
 <?php
-$str = "Τάχιστη αλώπηξ βαφής ψημένη γη, δρασκελίζει υπέρ νωθρού κυνός\n";
+$str = "Τάχιστη αλώπηξ βαφής ψημένη γη, δρασκελίζει υπέρ νωθρού κυνός";
 $str = mb_convert_case($str, MB_CASE_UPPER, "UTF-8");
-echo $str; // ΤΆΧΙΣΤΗ ΑΛΏΠΗΞ ΒΑΦΉΣ ΨΗΜΈΝΗ ΓΗ, ΔΡΑΣΚΕΛΊΖΕΙ ΥΠΈΡ ΝΩΘΡΟΎ ΚΥΝΌΣ
+echo $str, PHP_EOL;
 $str = mb_convert_case($str, MB_CASE_TITLE, "UTF-8");
-echo $str; // Τάχιστη Αλώπηξ Βαφήσ Ψημένη Γη, Δρασκελίζει Υπέρ Νωθρού Κυνόσ
+echo $str, PHP_EOL;
 ?>
 ]]>
     </programlisting>

--- a/reference/mbstring/functions/mb-convert-encoding.xml
+++ b/reference/mbstring/functions/mb-convert-encoding.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2c17cef6e71c3d85011319cde128cc4edf89a053 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: c1f37a6c270aadbbb3da56a3973ffd62197adf2b Maintainer: nilgun Status: ready -->
 <refentry xml:id="function.mb-convert-encoding" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_convert_encoding</refname>
@@ -149,7 +149,7 @@
   <para>
    <example>
     <title>- <function>mb_convert_encoding</function> örneği</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 /* Dahili karakter kodlamasını SJIS'e çevirelim */

--- a/reference/mbstring/functions/mb-convert-kana.xml
+++ b/reference/mbstring/functions/mb-convert-kana.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 68e632fcb78f682de178cbcac63ee648426e0c30 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 34f90a65914c900173f9a42331acc45bc53d8eee Maintainer: nilgun Status: ready -->
 <refentry xml:id="function.mb-convert-kana" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_convert_kana</refname>
@@ -210,23 +210,28 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>- <function>mb_convert_kana</function> örneği</title>
-    <programlisting role="php">
+  <example>
+   <title>- <function>mb_convert_kana</function> örneği</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
-/* "kana" kodlamasını "zen-kaku" "kata-kana" yapar*/
-$str = mb_convert_kana($str, "KVC");
+/* Tüm "han-kaku" "kata-kana" karakterlerini "zen-kaku" "hira-gana" karakterlerine dönüştürür */
+echo mb_convert_kana('ﾔﾏﾀﾞ ﾊﾅｺ', "HV") . "\n";
 
-/* "han-kaku" "kata-kana" kodlamasını "zen-kaku" "kata-kana"
-   ve "zen-kaku" harf ve sayılarını "han-kaku" yapar */
-$str = mb_convert_kana($str, "KVa");
+/* "han-kaku" "kata-kana" karakterlerini "zen-kaku" "kata-kana" karakterlerine,
+   "zen-kaku" harf ve sayıları "han-kaku" karakterlere dönüştürür */
+echo mb_convert_kana('ｺｳｻﾞﾊﾞﾝｺﾞｳ ０１２３４５６', "KVa") . "\n";
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+やまだ はなこ
+コウザバンゴウ 0123456
+]]>
+   </screen>
+  </example>
  </refsect1>
 
 </refentry>

--- a/reference/mbstring/functions/mb-strtolower.xml
+++ b/reference/mbstring/functions/mb-strtolower.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4afab59db15ea4b7c5dc2132d85932b4859bcf2 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 6c550e6d0c8139a0086095ef1db0ac6e08716e1f Maintainer: nilgun Status: ready -->
 <refentry xml:id="function.mb-strtolower" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_strtolower</refname>
@@ -45,6 +45,30 @@
   &reftitle.returnvalues;
   <para>
    İçindeki 'abecesel' karakterlerin tamamı küçük harfe çevrilmiş olarak <parameter>dizge</parameter> döner.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.3.0</entry>
+       <entry>
+        Yunanca sigma harfi için koşullu büyük-küçük harf kuralları gerçeklendi.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </para>
  </refsect1>
 


### PR DESCRIPTION
4 mbstring büyük/küçük harf ve kodlama dönüşüm işlevini son EN revizyonuna günceller.

Başlıca değişiklikler: mb_strtolower'a changelog bölümü ve Yunanca sigma için 8.3.0 girdisi eklendi, mb_convert_case changelog'una aynı kural eklendi ve örneklerdeki \"Prints\" yorum satırları PHP_EOL ile değiştirildi, mb_convert_encoding örneğine `annotations=\"non-interactive\"` özniteliği eklendi, mb_convert_kana örneği yeni biçimine (\&example.outputs; + screen) taşındı.