### PR TITLE
[Sync EN] datetime

### DIFF
--- a/reference/datetime/datetime.xml
+++ b/reference/datetime/datetime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: behzat Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: behzat Status: ready -->
 <reference xml:id="class.datetime" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>DateTime sınıfı</title>
@@ -79,6 +79,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Sınıf sabitleri artık tür belirtimli.
+       </entry>
+      </row>
       <row>
        <entry>7.2.0</entry>
        <entry>

--- a/reference/datetime/datetimeimmutable.xml
+++ b/reference/datetime/datetimeimmutable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: 576c7c43febb2eec5718d8320f92606423413983 Maintainer: nilgun Status: ready -->
 <reference xml:id="class.datetimeimmutable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>DateTimeImmutable sınıfı</title>
@@ -69,6 +69,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Sınıf sabitleri artık tür belirtimli.
+       </entry>
+      </row>
       <row>
        <entry>7.1.0</entry>
        <entry>

--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9eb4a46bba05da229be4c8f7a3cb64702e1a2f95 Maintainer: nilgun Status: ready -->
+<!-- EN-Revision: e1e7f1f922033c50c2fd2d33fc5e0512f4e76844 Maintainer: nilgun Status: ready -->
 <reference xml:id="class.datetimeinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>DateTimeInterface arayüzü</title>
@@ -149,17 +149,23 @@
    &reftitle.constants;
    <variablelist>
     <varlistentry xml:id="datetimeinterface.constants.atom">
-     <term><constant>DateTimeInterface::ATOM</constant></term>
+     <term>
+      <constant>DateTimeInterface::ATOM</constant>
+      <type>string</type>
+     </term>
      <term><constant>DATE_ATOM</constant></term>
      <listitem>
       <simpara>
-       Atom (örnek: 2005-08-15T15:52:01+00:00)
+       Atom (örnek: 2005-08-15T15:52:01+00:00); ISO-8601, RFC 3339 ve XML Schema ile uyumlu
       </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="datetimeinterface.constants.cookie">
-     <term><constant>DateTimeInterface::COOKIE</constant></term>
+     <term>
+      <constant>DateTimeInterface::COOKIE</constant>
+      <type>string</type>
+     </term>
      <term><constant>DATE_COOKIE</constant></term>
      <listitem>
       <simpara>
@@ -169,11 +175,14 @@
     </varlistentry>
 
     <varlistentry xml:id="datetimeinterface.constants.iso8601">
-     <term><constant>DateTimeInterface::ISO8601</constant></term>
+     <term>
+      <constant>DateTimeInterface::ISO8601</constant>
+      <type>string</type>
+     </term>
      <term><constant>DATE_ISO8601</constant></term>
      <listitem>
       <simpara>
-       ISO-8601 (örnek: 2005-08-15T15:52:01+0000)
+       ISO-8601 benzeri (örnek: 2005-08-15T15:52:01+0000)
       </simpara>
       <note>
        <simpara>
@@ -188,7 +197,10 @@
     </varlistentry>
 
     <varlistentry xml:id="datetimeinterface.constants.iso8601-expanded">
-     <term><constant>DateTimeInterface::ISO8601_EXPANDED</constant></term>
+     <term>
+      <constant>DateTimeInterface::ISO8601_EXPANDED</constant>
+      <type>string</type>
+     </term>
      <term><constant>DATE_ISO8601_EXPANDED</constant></term>
      <listitem>
       <simpara>
@@ -198,15 +210,18 @@
        <simpara>
         Bu biçim, her zaman bir işaret karakteri ekleyerek, ISO-8601'in normal
         aralığı olan <literal>0000</literal>-<literal>9999</literal> dışındaki
-        yıl aralıklarına izin verir. Ayrıca, bu zaman dilimi bölümünün
-        (<literal>+01:00</literal>) ISO-8601 ile uyumlu olduğunu da belirtir.
+        yıl aralıklarına izin verir. Ayrıca, zaman dilimi bölümünün
+        (<literal>+01:00</literal>) ISO-8601 ile uyumlu olmasını sağlar.
        </simpara>
       </note>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="datetimeinterface.constants.rfc822">
-     <term><constant>DateTimeInterface::RFC822</constant></term>
+     <term>
+      <constant>DateTimeInterface::RFC822</constant>
+      <type>string</type>
+     </term>
      <term><constant>DATE_RFC822</constant></term>
      <listitem>
       <simpara>
@@ -216,7 +231,10 @@
     </varlistentry>
 
     <varlistentry xml:id="datetimeinterface.constants.rfc850">
-     <term><constant>DateTimeInterface::RFC850</constant></term>
+     <term>
+      <constant>DateTimeInterface::RFC850</constant>
+      <type>string</type>
+     </term>
      <term><constant>DATE_RFC850</constant></term>
      <listitem>
       <simpara>
@@ -226,7 +244,10 @@
     </varlistentry>
 
     <varlistentry xml:id="datetimeinterface.constants.rfc1036">
-     <term><constant>DateTimeInterface::RFC1036</constant></term>
+     <term>
+      <constant>DateTimeInterface::RFC1036</constant>
+      <type>string</type>
+     </term>
      <term><constant>DATE_RFC1036</constant></term>
      <listitem>
       <simpara>
@@ -236,7 +257,10 @@
     </varlistentry>
 
     <varlistentry xml:id="datetimeinterface.constants.rfc1123">
-     <term><constant>DateTimeInterface::RFC1123</constant></term>
+     <term>
+      <constant>DateTimeInterface::RFC1123</constant>
+      <type>string</type>
+     </term>
      <term><constant>DATE_RFC1123</constant></term>
      <listitem>
       <simpara>
@@ -246,7 +270,10 @@
     </varlistentry>
 
     <varlistentry xml:id="datetimeinterface.constants.rfc7231">
-      <term><constant>DateTimeInterface::RFC7231</constant></term>
+      <term>
+       <constant>DateTimeInterface::RFC7231</constant>
+       <type>string</type>
+      </term>
       <term><constant>DATE_RFC7231</constant></term>
       <listitem>
        <simpara>
@@ -256,7 +283,10 @@
     </varlistentry>
 
     <varlistentry xml:id="datetimeinterface.constants.rfc2822">
-     <term><constant>DateTimeInterface::RFC2822</constant></term>
+     <term>
+      <constant>DateTimeInterface::RFC2822</constant>
+      <type>string</type>
+     </term>
      <term><constant>DATE_RFC2822</constant></term>
      <listitem>
       <simpara>
@@ -266,7 +296,10 @@
     </varlistentry>
 
     <varlistentry xml:id="datetimeinterface.constants.rfc3339">
-     <term><constant>DateTimeInterface::RFC3339</constant></term>
+     <term>
+      <constant>DateTimeInterface::RFC3339</constant>
+      <type>string</type>
+     </term>
      <term><constant>DATE_RFC3339</constant></term>
      <listitem>
       <simpara>
@@ -276,7 +309,10 @@
     </varlistentry>
 
     <varlistentry xml:id="datetimeinterface.constants.rfc3339-extended">
-     <term><constant>DateTimeInterface::RFC3339_EXTENDED</constant></term>
+     <term>
+      <constant>DateTimeInterface::RFC3339_EXTENDED</constant>
+      <type>string</type>
+     </term>
      <term><constant>DATE_RFC3339_EXTENDED</constant></term>
      <listitem>
       <simpara>
@@ -287,7 +323,10 @@
     </varlistentry>
 
     <varlistentry xml:id="datetimeinterface.constants.rss">
-     <term><constant>DateTimeInterface::RSS</constant></term>
+     <term>
+      <constant>DateTimeInterface::RSS</constant>
+      <type>string</type>
+     </term>
      <term><constant>DATE_RSS</constant></term>
      <listitem>
       <simpara>
@@ -297,7 +336,10 @@
     </varlistentry>
 
     <varlistentry xml:id="datetimeinterface.constants.w3c">
-     <term><constant>DateTimeInterface::W3C</constant></term>
+     <term>
+      <constant>DateTimeInterface::W3C</constant>
+      <type>string</type>
+     </term>
      <term><constant>DATE_W3C</constant></term>
      <listitem>
       <simpara>
@@ -322,6 +364,18 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        <constant>DATE_RFC7231</constant> ve
+        <constant>DateTimeInterface::RFC7231</constant> sabitlerinin kullanımı
+        önerilmiyor.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>Sınıf sabitleri artık tür belirtimli.</entry>
+      </row>
       <row>
        <entry>8.2.0</entry>
        <entry>

--- a/reference/datetime/datetimezone.xml
+++ b/reference/datetime/datetimezone.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 576c7c43febb2eec5718d8320f92606423413983 Maintainer: behzat Status: ready -->
 <reference xml:id="class.datetimezone" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>DateTimeZone sınıfı</title>
@@ -130,85 +130,127 @@
    &reftitle.constants;
     <variablelist>
      <varlistentry xml:id="datetimezone.constants.africa">
-      <term><constant>DateTimeZone::AFRICA</constant></term>
+      <term>
+       <constant>DateTimeZone::AFRICA</constant>
+       <type>int</type>
+      </term>
       <listitem>
        <para>Afrika zaman dilimleri.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="datetimezone.constants.america">
-      <term><constant>DateTimeZone::AMERICA</constant></term>
+      <term>
+       <constant>DateTimeZone::AMERICA</constant>
+       <type>int</type>
+      </term>
       <listitem>
        <para>Amerika zaman dilimleri.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="datetimezone.constants.antarctica">
-      <term><constant>DateTimeZone::ANTARCTICA</constant></term>
+      <term>
+       <constant>DateTimeZone::ANTARCTICA</constant>
+       <type>int</type>
+      </term>
       <listitem>
        <para>Antarktika zaman dilimleri.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="datetimezone.constants.arctic">
-      <term><constant>DateTimeZone::ARCTIC</constant></term>
+      <term>
+       <constant>DateTimeZone::ARCTIC</constant>
+       <type>int</type>
+      </term>
       <listitem>
        <para>Kuzey Kutup Dairesi zaman dilimleri.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="datetimezone.constants.asia">
-      <term><constant>DateTimeZone::ASIA</constant></term>
+      <term>
+       <constant>DateTimeZone::ASIA</constant>
+       <type>int</type>
+      </term>
       <listitem>
        <para>Asya zaman dilimleri.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="datetimezone.constants.atlantic">
-      <term><constant>DateTimeZone::ATLANTIC</constant></term>
+      <term>
+       <constant>DateTimeZone::ATLANTIC</constant>
+       <type>int</type>
+      </term>
       <listitem>
        <para>Atlantik zaman dilimleri.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="datetimezone.constants.australia">
-      <term><constant>DateTimeZone::AUSTRALIA</constant></term>
+      <term>
+       <constant>DateTimeZone::AUSTRALIA</constant>
+       <type>int</type>
+      </term>
       <listitem>
        <para>Avustralya zaman dilimleri.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="datetimezone.constants.europe">
-      <term><constant>DateTimeZone::EUROPE</constant></term>
+      <term>
+       <constant>DateTimeZone::EUROPE</constant>
+       <type>int</type>
+      </term>
       <listitem>
        <para>Avrupa zaman dilimleri.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="datetimezone.constants.indian">
-      <term><constant>DateTimeZone::INDIAN</constant></term>
+      <term>
+       <constant>DateTimeZone::INDIAN</constant>
+       <type>int</type>
+      </term>
       <listitem>
        <para>Hindistan zaman dilimleri.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="datetimezone.constants.pacific">
-      <term><constant>DateTimeZone::PACIFIC</constant></term>
+      <term>
+       <constant>DateTimeZone::PACIFIC</constant>
+       <type>int</type>
+      </term>
       <listitem>
        <para>Pasifik zaman dilimleri.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="datetimezone.constants.utc">
-      <term><constant>DateTimeZone::UTC</constant></term>
+      <term>
+       <constant>DateTimeZone::UTC</constant>
+       <type>int</type>
+      </term>
       <listitem>
        <para>UTC zaman dilimleri.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="datetimezone.constants.all">
-      <term><constant>DateTimeZone::ALL</constant></term>
+      <term>
+       <constant>DateTimeZone::ALL</constant>
+       <type>int</type>
+      </term>
       <listitem>
        <para>Tüm zaman dilimleri.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="datetimezone.constants.all-with-bc">
-      <term><constant>DateTimeZone::ALL_WITH_BC</constant></term>
+      <term>
+       <constant>DateTimeZone::ALL_WITH_BC</constant>
+       <type>int</type>
+      </term>
       <listitem>
        <para>Geriye uyumluluk dahil tüm zaman dilimleri.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="datetimezone.constants.per-country">
-      <term><constant>DateTimeZone::PER_COUNTRY</constant></term>
+      <term>
+       <constant>DateTimeZone::PER_COUNTRY</constant>
+       <type>int</type>
+      </term>
       <listitem>
        <para>Ülkelere göre zaman dilimleri.</para>
       </listitem>
@@ -216,7 +258,27 @@
     </variablelist>
   </section>
 <!-- }}} -->
-
+  <section role="changelog" xml:id="datetimezone.changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Sınıf sabitleri artık tür belirtimli.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/datetime/datetimezone/construct.xml
+++ b/reference/datetime/datetimezone/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d9ac376dbee6e45ef775059456caf0ec348ada6a Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: behzat Status: ready -->
 <refentry xml:id="datetimezone.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeZone::__construct</refname>
@@ -115,17 +115,18 @@ foreach ($timezones as $tz) {
     $tzo = new DateTimeZone($tz);
 
     $local = $d->setTimezone($tzo);
-    echo $local->format(DateTimeInterface::RFC2822 . ' — e'), "\n";
+    echo $local->format(DateTimeInterface::RFC2822 . ' — e') . "\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
+<![CDATA[
 Thu, 02 Jun 2022 16:44:48 +0100 — Europe/London
 Thu, 02 Jun 2022 20:29:48 +0445 — +04:45
 Thu, 02 Jun 2022 09:44:48 -0600 — -06:00
-Thu, 02 Jun 2022 16:44:48 +0100 — CEST
+Thu, 02 Jun 2022 17:44:48 +0200 — CEST
+]]>
     </screen>
    </example>
   </para>
@@ -143,16 +144,17 @@ $zamandilimleri = array('Europe/Istanbul', 'Mars/Phobos', 'Jupiter/Europa');
 foreach ($zamandilimleri as $zd) {
     try {
         $mars = new DateTimeZone($zd);
+        echo $mars->getName() . "\n";
     } catch(Exception $e) {
-        echo $e->getMessage() . '<br />';
+        echo $e->getMessage() . "\n";
     }
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
+Europe/Istanbul
 DateTimeZone::__construct() [datetimezone.--construct]: Unknown or bad timezone (Mars/Phobos)
 DateTimeZone::__construct() [datetimezone.--construct]: Unknown or bad timezone (Jupiter/Europa)
 ]]>

--- a/reference/datetime/datetimezone/getlocation.xml
+++ b/reference/datetime/datetimezone/getlocation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: behzat Status: ready -->
 <refentry xml:id="datetimezone.getlocation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeZone::getLocation</refname>
@@ -50,10 +50,9 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$tz = new DateTimeZone("Europe/Prague");
+$tz = new DateTimeZone("Asia/Jakarta");
 print_r($tz->getLocation());
 print_r(timezone_location_get($tz));
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -61,21 +60,30 @@ print_r(timezone_location_get($tz));
 <![CDATA[
 Array
 (
-    [country_code] => CZ
-    [latitude] => 50.08333
-    [longitude] => 14.43333
-    [comments] =>
+    [country_code] => ID
+    [latitude] => -6.16667
+    [longitude] => 106.8
+    [comments] => Java, Sumatra
 )
 Array
 (
-    [country_code] => CZ
-    [latitude] => 50.08333
-    [longitude] => 14.43333
-    [comments] =>
+    [country_code] => ID
+    [latitude] => -6.16667
+    [longitude] => 106.8
+    [comments] => Java, Sumatra
 )
 ]]>
     </screen>
    </example>
+  </para>
+  <para>
+   <literal>country_code</literal> elemanları, her bir girdi için ISO 3166-1
+   alpha-2 ülke kodunu içerir. <literal>latitude</literal> ve
+   <literal>longitude</literal> elemanları, zaman dilimi tanımlayıcısındaki
+   şehrin koordinatlarını, <literal>comments</literal> elemanı ise
+   (&false; olmadığında) bu zaman diliminin verilen ülkede nerelerde
+   uygulandığına dair bir ipucunu içerir. Bu bilgi son kullanıcılara
+   sunulmaya uygundur.
   </para>
  </refsect1>
 


### PR DESCRIPTION
6 DateTime ailesi sınıfı ve DateTimeZone yönteminin son EN revizyonuna güncellenmesi.

Başlıca değişiklikler: tüm sınıf sabitlerine PHP 8.4'te eklenen tür belirtimi (DateTime, DateTimeImmutable, DateTimeInterface, DateTimeZone changelog girdileri); DateTimeInterface::ATOM açıklamasına ISO-8601/RFC 3339/XML Schema uyumluluk notu, ISO8601 "benzeri" olarak yeniden ifade edildi; 8.5.0'da RFC7231 kullanımdan kaldırma changelog girdisi; DateTimeZone::__construct ve getLocation örneklerinin yeniden düzenlenmesi.