### PR TITLE
[Sync EN] datetime: DateInterval, DatePeriod ve yöntemleri

### DIFF
--- a/reference/datetime/dateinterval.xml
+++ b/reference/datetime/dateinterval.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9154789dfc9cb8aa5df644bfba5e86c2deba4cb8 Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: behzat Status: ready -->
 <reference xml:id="class.dateinterval" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>DateInterval sınıfı</title>

--- a/reference/datetime/dateinterval/construct.xml
+++ b/reference/datetime/dateinterval/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 71692b6f4cace8dca72a18ccd80d4cd7305e5d4e Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: behzat Status: ready -->
 <refentry xml:id="dateinterval.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateInterval::__construct</refname>
@@ -185,7 +185,9 @@ echo $interval->format("%d");
     </programlisting>
     &example.outputs;
     <screen role="php">
+<![CDATA[
 7
+]]>
     </screen>
    </example>
   </para>
@@ -196,11 +198,8 @@ echo $interval->format("%d");
     <programlisting role="php">
 <![CDATA[
 <?php
-
 $interval = new DateInterval('P1W2D');
 var_dump($interval);
-
-?>
 ]]>
     </programlisting>
     &example.outputs.82;

--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd1ae73f4a88404c9a3015940c66a85aaeec5889 Maintainer: behzat Status: ready -->
+<!-- EN-Revision: c0c9d7721b5a8564a4e27671389a456c1be13e6b Maintainer: behzat Status: ready -->
 <refentry xml:id="dateinterval.createfromdatestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateInterval::createFromDateString</refname>
@@ -10,7 +10,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="DateInterval">
-   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>DateInterval</type><type>false</type></type><methodname>DateInterval::createFromDateString</methodname>
+   <modifier>public</modifier> <modifier>static</modifier> <type>DateInterval</type><methodname>DateInterval::createFromDateString</methodname>
    <methodparam><type>string</type><parameter>zaman</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>
@@ -40,7 +40,7 @@
        gösterimler</link> kullanılır.
       </para>
       <para>
-       <literal>P7D</literal> gibi bir ISO-8601 biçem dizgesini kullanmak için kurucu gerekir.
+       <literal>P7D</literal> gibi bir ISO-8601 biçem dizgesini kullanmak için <methodname>DateInterval::__construct</methodname> gerekir.
       </para>
      </listitem>
     </varlistentry>
@@ -51,8 +51,17 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Başarılıysa yeni bir <classname>DateInterval</classname> nesnesi döndürür,
-   &return.falseforfailure;.
+   Başarılıysa bir <classname>DateInterval</classname> döndürür.
+   &return.falseforfailure.style.procedural;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Yalnızca Nesneye Yönelik API: Geçersiz bir Tarih/Zaman dizgesi aktarılırsa
+   <exceptionname>DateMalformedIntervalStringException</exceptionname>
+   yavrulanır.
   </para>
  </refsect1>
 
@@ -67,6 +76,17 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       Geçersiz bir dizge aktarılırsa
+       <methodname>DateInterval::createFromDateString</methodname> artık
+       <exceptionname>DateMalformedIntervalStringException</exceptionname>
+       yavruluyor. Evvelce <literal>false</literal> dönerdi ve bir uyarı
+       üretirdi. <function>date_interval_create_from_date_string</function>
+       işlevinin davranışı değişmedi.
+      </entry>
+     </row>
      <row>
       <entry>8.2.0</entry>
       <entry>
@@ -84,7 +104,7 @@
   <para>
    <example>
     <title>- Geçerli tarih aralıklarının çözümlenmesi</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // Aralıklar her birinde eşittir.
@@ -108,7 +128,6 @@ $i = DateInterval::createFromDateString('1 day + 12 hours');
 
 $i = new DateInterval('PT3600S');
 $i = DateInterval::createFromDateString('3600 seconds');
-?>
 ]]>
     </programlisting>
    </example>
@@ -124,13 +143,14 @@ echo $i->format('%d %h %i'), "\n";
 
 $i = DateInterval::createFromDateString('1 year - 10 days');
 echo $i->format('%y %d'), "\n";
-?>
 ]]>
     </programlisting>
     &example.outputs;
-    <screen role="shell">
+    <screen>
+<![CDATA[
 449 2 70
 1 -10
+]]>
     </screen>
    </example>
   </para>

--- a/reference/datetime/dateinterval/format.xml
+++ b/reference/datetime/dateinterval/format.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: behzat Status: ready -->
 <refentry xml:id="dateinterval.format" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateInterval::format</refname>
@@ -197,11 +197,8 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-
 $interval = new DateInterval('P2Y4DT6H8M');
 echo $interval->format('%d gün');
-
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -218,11 +215,8 @@ echo $interval->format('%d gün');
     <programlisting role="php">
 <![CDATA[
 <?php
-
 $interval = new DateInterval('P32D');
 echo $interval->format('%d gün');
-
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -242,7 +236,6 @@ echo $interval->format('%d gün');
     <programlisting role="php">
 <![CDATA[
 <?php
-
 $january = new DateTime('2010-01-01');
 $february = new DateTime('2010-02-01');
 $interval = $february->diff($january);
@@ -252,8 +245,6 @@ echo $interval->format('toplam %a gün')."\n";
 
 // %d ise aya dahil olmayan gün sayısını çıktılar.
 echo $interval->format('%m ay, %d gün');
-
-?>
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/datetime/dateperiod.xml
+++ b/reference/datetime/dateperiod.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ac83abe55f4da019036de5ec14400d674fa3f9f5 Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: behzat Status: ready -->
 <reference xml:id="class.dateperiod" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>DatePeriod sınıfı</title>
@@ -112,7 +112,10 @@
    &reftitle.constants;
    <variablelist>
     <varlistentry xml:id="dateperiod.constants.exclude-start-date">
-     <term><constant>DatePeriod::EXCLUDE_START_DATE</constant></term>
+     <term>
+      <constant>DatePeriod::EXCLUDE_START_DATE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
         <function>DatePeriod::__construct</function> yönteminde kullanılan
@@ -122,7 +125,10 @@
     </varlistentry>
 
     <varlistentry xml:id="dateperiod.constants.include-end-date">
-     <term><constant>DatePeriod::INCLUDE_END_DATE</constant></term>
+     <term>
+      <constant>DatePeriod::INCLUDE_END_DATE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        <function>DatePeriod::__construct</function> yönteminde kullanılan
@@ -163,7 +169,8 @@
       <para>
        <informalexample>
         <programlisting role="php">
-<![CDATA[<?php
+<![CDATA[
+<?php
 $start = new DateTime('2018-12-31 00:00:00');
 $end   = new DateTime('2021-12-31 00:00:00');
 $interval = new DateInterval('P1M');
@@ -185,15 +192,17 @@ echo $period->recurrences, "\n";
 
 $period = new DatePeriod($start, $interval, $end, DatePeriod::EXCLUDE_START_DATE);
 echo $period->recurrences, "\n";
-?>]]>
+]]>
          </programlisting>
          &example.outputs;
          <screen role="php">
+<![CDATA[
 5
 6
 7
 1
 0
+]]>
          </screen>
        </informalexample>
        </para>
@@ -265,6 +274,12 @@ echo $period->recurrences, "\n";
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Sınıf sabitleri artık tür belirtimli.
+       </entry>
+      </row>
       <row>
        <entry>8.2.0</entry>
        <entry>

--- a/reference/datetime/dateperiod/construct.xml
+++ b/reference/datetime/dateperiod/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7d81260767f008218ffd338b365cfa3d10eb3d15 Maintainer: behzat Status: ready -->
+<!-- EN-Revision: 0cf48a5a4869bd8b42f84e7032076756cde6a474 Maintainer: behzat Status: ready -->
 <refentry xml:id="dateperiod.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DatePeriod::__construct</refname>
@@ -24,15 +24,17 @@
    <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
   </constructorsynopsis>
   <warning>
+   <simpara>
+    Aşağıdaki kurucu kullanımı artık önerilmiyor:
+   </simpara>
    <constructorsynopsis role="DatePeriod">
     <modifier>public</modifier> <methodname>DatePeriod::__construct</methodname>
     <methodparam><type>string</type><parameter>isostr</parameter></methodparam>
     <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
    </constructorsynopsis>
    <simpara>
-    Bu kullanım artık önerilmiyor, yerine
-    <methodname>DatePeriod::createFromISO8601String</methodname>
-    kullanılmalıdır.
+    Yerine <methodname>DatePeriod::createFromISO8601String</methodname>
+    durağan üretici yöntemi kullanılmalıdır.
    </simpara>
   </warning>
   <para>
@@ -214,12 +216,12 @@ $period = new DatePeriod($iso);
 foreach ($period as $date) {
     echo $date->format('Y-m-d')."\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
+Deprecated: Calling DatePeriod::__construct(string $isostr, int $options = 0) is deprecated, use DatePeriod::createFromISO8601String() instead in script on line 11
 2012-07-01
 2012-07-08
 2012-07-15
@@ -249,7 +251,6 @@ $period = new DatePeriod($start, $interval, $end,
 foreach ($period as $date) {
     echo $date->format('Y-m-d')."\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -278,7 +279,6 @@ $period = new DatePeriod($begin, $interval, $end, DatePeriod::EXCLUDE_START_DATE
 foreach ($period as $dt) {
     echo $dt->format('l Y-m-d'), "\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;


### PR DESCRIPTION
DateInterval ve DatePeriod sınıfları ile yöntemlerinin son EN revizyonuna güncellenmesi (6 dosya).

Başlıca değişiklikler: DateInterval::createFromDateString için 8.3.0 changelog girdisi (DateMalformedIntervalStringException) ve errors bölümü, dönüş türü dizgiden DateInterval'e basitleştirildi; DatePeriod sınıf sabitlerine 8.4.0 tür belirtimi (int); DatePeriod::__construct uyarı bloğunun yeniden ifadesi ve örnek çıktısına Deprecated mesaj girdisi; örneklerde "?>" sonlandırıcılar ve gereksiz boş satırlar kaldırıldı, screen bloklarına eksik CDATA sarmalları eklendi.