### PR TITLE
[Translate] random + info

### DIFF
--- a/reference/info/functions/ini-parse-quantity.xml
+++ b/reference/info/functions/ini-parse-quantity.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4c016ab334b90a98258b98e04752af7dc74954cd Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.ini-parse-quantity" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>ini_parse_quantity</refname>
+  <refpurpose>Ini kısa gösteriminden yorumlanmış boyutu döndürür</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>ini_parse_quantity</methodname>
+   <methodparam><type>string</type><parameter>kısa_gösterim</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Başarı durumunda bir
+   <link linkend="faq.using.shorthandbytes">ini kısa gösteriminden</link>
+   yorumlanmış boyutu bayt cinsinden döndürür.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>kısa_gösterim</parameter></term>
+     <listitem>
+      <para>
+       Çözümlenecek ini kısa gösterimi; bir sayı ve isteğe bağlı bir çarpan
+       içermelidir.
+
+       Aşağıdaki çarpanlar desteklenir:
+       <literal>k</literal>/<literal>K</literal> (<literal>1024</literal>),
+       <literal>m</literal>/<literal>M</literal> (<literal>1048576</literal>),
+       <literal>g</literal>/<literal>G</literal> (<literal>1073741824</literal>).
+
+       Sayı; onluk, onaltılık (<literal>0x</literal> veya <literal>0X</literal>
+       ön ekiyle), sekizlik (<literal>0o</literal>, <literal>0O</literal> veya
+       <literal>0</literal> ön ekiyle) ya da ikilik (<literal>0b</literal>
+       veya <literal>0B</literal> ön ekiyle) olabilir.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Yorumlanmış boyutu bayt cinsinden bir &integer; olarak döndürür.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Değer çözümlenemiyorsa veya geçersiz bir çarpan kullanılmışsa
+   <constant>E_WARNING</constant> seviyesinde bir uyarı üretilir.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Birkaç <function>ini_parse_quantity</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+var_dump(ini_parse_quantity('1024'));
+var_dump(ini_parse_quantity('1024M'));
+var_dump(ini_parse_quantity('512K'));
+var_dump(ini_parse_quantity('0xFFk'));
+var_dump(ini_parse_quantity('0b1010k'));
+var_dump(ini_parse_quantity('0o1024'));
+var_dump(ini_parse_quantity('01024'));
+var_dump(ini_parse_quantity('Foobar'));
+var_dump(ini_parse_quantity('10F'));
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+
+int(1024)
+int(1073741824)
+int(524288)
+int(261120)
+int(10240)
+int(532)
+int(532)
+
+Warning: Invalid quantity "Foobar": no valid leading digits, interpreting as "0" for backwards compatibility
+int(0)
+
+Warning: Invalid quantity "10F": unknown multiplier "F", interpreting as "10" for backwards compatibility
+int(10)
+
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ini_get</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/info/functions/memory-reset-peak-usage.xml
+++ b/reference/info/functions/memory-reset-peak-usage.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 57015edfe2dd12072d591057eac5461c37320be4 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.memory-reset-peak-usage" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>memory_reset_peak_usage</refname>
+  <refpurpose>En yüksek bellek kullanımını sıfırlar</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>memory_reset_peak_usage</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   <function>memory_get_peak_usage</function> işlevi tarafından döndürülen
+   en yüksek bellek kullanım değerini sıfırlar.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>memory_reset_peak_usage</function> örneği</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+var_dump(memory_get_peak_usage());
+
+$a = str_repeat("Hello", 424242);
+var_dump(memory_get_peak_usage());
+
+unset($a);
+memory_reset_peak_usage();
+
+$a = str_repeat("Hello", 2424);
+var_dump(memory_get_peak_usage());
+
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+int(422440)
+int(2508672)
+int(399208)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>memory_get_peak_usage</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/random/functions/random-bytes.xml
+++ b/reference/random/functions/random-bytes.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: f08b9a8aee8330c248cd84b3f546391fedccd9f1 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.random-bytes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>random_bytes</refname>
+  <refpurpose>Kriptografik olarak güvenli rastgele baytlar üretir</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description"><!-- {{{ -->
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>random_bytes</methodname>
+   <methodparam><type>int</type><parameter>uzunluk</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   İstenen <parameter>uzunluk</parameter> kadar düzgün dağılımlı rastgele
+   baytlar içeren bir dizge üretir.
+  </para>
+  <para>
+   Dönen baytlar tamamen rastgele seçildiğinden, sonuç dizgesi büyük
+   olasılıkla yazdırılamayan karakterler veya geçersiz UTF-8 dizileri
+   içerecektir. Aktarma veya görüntülemeden önce kodlanması gerekebilir.
+  </para>
+  <para>
+   Bu işlevin ürettiği rastgelelik, şifreleme anahtarları gibi uzun ömürlü
+   gizli değerlerin üretimi dahil tüm uygulamalar için uygundur.
+  </para>
+  &csprng.sources;
+  &csprng.function.backport;
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="parameters"><!-- {{{ -->
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uzunluk</parameter></term>
+    <listitem>
+     <para>
+      Döndürülmesi gereken rastgele dizgenin bayt cinsinden uzunluğu;
+      <literal>1</literal> veya daha büyük olmalıdır.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="returnvalues"><!-- {{{ -->
+  &reftitle.returnvalues;
+  <para>
+   İstenen sayıda kriptografik olarak güvenli rastgele bayt içeren bir dizge.
+  </para>
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="errors"><!-- {{{ -->
+  &reftitle.errors;
+  <itemizedlist>
+   &csprng.errors;
+   <listitem>
+    <simpara>
+     <parameter>uzunluk</parameter> değeri <literal>1</literal>'den küçükse
+     bir <classname>ValueError</classname> yavrulanır.
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.2.0</entry>
+      <entry>
+       Bir <acronym>CSPRNG</acronym> hatası durumunda bu işlev artık bir
+       <classname>Random\RandomException</classname> yavruluyor. Evvelce
+       sıradan bir <classname>Exception</classname> yavrulanıyordu.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples"><!-- {{{ -->
+  &reftitle.examples;
+  <example xml:id="random-bytes.example.basic"><!-- {{{ -->
+   <title><function>random_bytes</function> örneği</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$bytes = random_bytes(5);
+var_dump(bin2hex($bytes));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+string(10) "385e33f741"
+]]>
+   </screen>
+  </example><!-- }}} -->
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="seealso"><!-- {{{ -->
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>Random\Randomizer::getBytes</function></member>
+   <member><function>random_int</function></member>
+   <member><function>bin2hex</function></member>
+   <member><function>base64_encode</function></member>
+  </simplelist>
+ </refsect1><!-- }}} -->
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/random/functions/random-int.xml
+++ b/reference/random/functions/random-int.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0ec8e36e0f649354b20c714080a903d32df4dbfb Maintainer: lacatoire Status: ready -->
+
+<refentry xml:id="function.random-int" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>random_int</refname>
+  <refpurpose>Kriptografik olarak güvenli, düzgün dağılımlı bir tamsayı üretir</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description"><!-- {{{ -->
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>random_int</methodname>
+   <methodparam><type>int</type><parameter>asgari</parameter></methodparam>
+   <methodparam><type>int</type><parameter>azami</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Belirtilen asgari ve azami değerler arasında düzgün dağılımlı bir tamsayı
+   üretir.
+  </para>
+  <para>
+   Bu işlevin ürettiği rastgelelik, şifreleme anahtarları gibi uzun ömürlü
+   gizli değerlerin üretimi dahil tüm uygulamalar için uygundur.
+  </para>
+  &csprng.sources;
+  &csprng.function.backport;
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="parameters"><!-- {{{ -->
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>asgari</parameter></term>
+    <listitem>
+     <para>
+      Döndürülebilecek en küçük değer.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>azami</parameter></term>
+    <listitem>
+     <para>
+      Döndürülebilecek en büyük değer.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="returnvalues"><!-- {{{ -->
+  &reftitle.returnvalues;
+  <para>
+   Kapalı aralık [<parameter>asgari</parameter>, <parameter>azami</parameter>]
+   içinden kriptografik olarak güvenli, düzgün dağılımlı bir tamsayı.
+   Hem <parameter>asgari</parameter> hem de <parameter>azami</parameter> olası
+   dönüş değerleridir.
+  </para>
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="errors"><!-- {{{ -->
+  &reftitle.errors;
+  <itemizedlist>
+   &csprng.errors;
+   <listitem>
+    <simpara>
+     <parameter>azami</parameter> <parameter>asgari</parameter>'den
+     küçükse bir <classname>ValueError</classname> yavrulanır.
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.2.0</entry>
+      <entry>
+       Bir <acronym>CSPRNG</acronym> hatası durumunda bu işlev artık bir
+       <classname>Random\RandomException</classname> yavruluyor. Evvelce
+       sıradan bir <classname>Exception</classname> yavrulanıyordu.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples"><!-- {{{ -->
+  &reftitle.examples;
+  <example xml:id="random-int.example.basic"><!-- {{{ -->
+   <title><function>random_int</function> örneği</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(random_int(100, 999));
+var_dump(random_int(-1000, 0));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(248)
+int(-898)
+]]>
+   </screen>
+  </example><!-- }}} -->
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="seealso"><!-- {{{ -->
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Random\Randomizer::getInt</methodname></member>
+   <member><function>random_bytes</function></member>
+  </simplelist>
+ </refsect1><!-- }}} -->
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/random/functions/srand.xml
+++ b/reference/random/functions/srand.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 37cf0c5a0c66e94e4184e81d7dccc8eed001b66f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.srand" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>srand</refname>
+  <refpurpose>Rastgele sayı üretecini tohumlar</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+   <methodsynopsis>
+   <type>void</type><methodname>srand</methodname>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>tohum</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>kip</parameter><initializer><constant>MT_RAND_MT19937</constant></initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Rastgele sayı üretecini <parameter>tohum</parameter> ile, ya da
+   <parameter>tohum</parameter> belirtilmemişse rastgele bir değerle
+   tohumlar.
+  </para>
+
+  &note.randomseed;
+  &caution.mt19937-tiny-seed;
+  <note><simpara>PHP 7.1.0 itibariyle, <function>srand</function> işlevi
+   <function>mt_srand</function> işlevinin bir takma adı olmuştur.</simpara>
+  </note>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>tohum</parameter></term>
+     <listitem>
+      <para>
+       İçsel durumu, <parameter>tohum</parameter> ile tohumlanmış bir
+       doğrusal eşleşik üretecin ürettiği, işaretsiz 32 bitlik tamsayı
+       olarak yorumlanan değerlerle doldurur.
+      </para>
+      <para>
+       <parameter>tohum</parameter> belirtilmemişse veya &null; ise,
+       rastgele işaretsiz 32 bitlik bir tamsayı kullanılır.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.3.0</entry>
+       <entry>
+        <parameter>tohum</parameter> artık &null; olabiliyor.
+       </entry>
+      </row>
+      <row>
+       <entry>7.1.0</entry>
+       <entry>
+        <function>srand</function> işlevi <link linkend="migration71.incompatible.rand-srand-aliases">artık</link> <function>mt_srand</function> işlevinin bir takma adıdır.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>rand</function></member>
+    <member><function>getrandmax</function></member>
+    <member><function>mt_srand</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
random ve info modüllerindeki kalan 5 işlevin çevirisi: random_bytes, random_int, srand (random modülünü tamamlar) ile ini_parse_quantity, memory_reset_peak_usage (info için kalan iki işlev).

Terminoloji README sözlüğüne ve corpus'a göre uyumlandırıldı: tohum, kip, asgari/azami, kısa gösterim, en yüksek bellek kullanımı, yavrulanır.